### PR TITLE
Feature/allow-list

### DIFF
--- a/db/migrations/pool/supernets-0001.sql
+++ b/db/migrations/pool/supernets-0001.sql
@@ -1,0 +1,20 @@
+-- +migrate Down
+DROP TABLE IF EXISTS pool.acl CASCADE;
+DROP TABLE IF EXISTS pool.policy CASCADE;
+
+-- +migrate Up
+CREATE TABLE pool.policy
+(
+    name VARCHAR PRIMARY KEY,
+    allow BOOLEAN NOT NULL DEFAULT false
+);
+
+INSERT INTO pool.policy (name, allow) VALUES ('send_tx', true);
+INSERT INTO pool.policy (name, allow) VALUES ('deploy', true);
+
+CREATE TABLE pool.acl
+(
+    address VARCHAR,
+    policy  VARCHAR,
+    PRIMARY KEY (address, policy)
+);

--- a/jsonrpc/endpoints_eth.go
+++ b/jsonrpc/endpoints_eth.go
@@ -800,6 +800,10 @@ func (e *EthEndpoints) SendRawTransaction(httpRequest *http.Request, input strin
 	if e.cfg.SequencerNodeURI != "" {
 		return e.relayTxToSequencerNode(input)
 	} else {
+		if err := checkPolicy(context.Background(), e.pool, input); err != nil {
+			return RPCErrorResponse(types.AccessDeniedCode, err.Error(), nil)
+		}
+
 		ip := ""
 		ips := httpRequest.Header.Get("X-Forwarded-For")
 

--- a/jsonrpc/endpoints_eth_test.go
+++ b/jsonrpc/endpoints_eth_test.go
@@ -3211,6 +3211,7 @@ func TestSendRawTransactionViaGeth(t *testing.T) {
 	}
 
 	testCases := []testCase{
+
 		{
 			Name:          "Send TX successfully",
 			Tx:            ethTypes.NewTransaction(1, common.HexToAddress("0x1"), big.NewInt(1), uint64(1), big.NewInt(1), []byte{}),
@@ -3333,6 +3334,238 @@ func TestSendRawTransactionJSONRPCCall(t *testing.T) {
 				tc.ExpectedError = types.NewRPCError(types.InvalidParamsErrorCode, "invalid tx input")
 			},
 			SetupMocks: func(t *testing.T, m *mocksWrapper, tc testCase) {},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			tc := testCase
+			tc.Prepare(t, &tc)
+			tc.SetupMocks(t, m, tc)
+
+			res, err := s.JSONRPCCall("eth_sendRawTransaction", tc.Input)
+			require.NoError(t, err)
+
+			assert.Equal(t, float64(1), res.ID)
+			assert.Equal(t, "2.0", res.JSONRPC)
+
+			if res.Result != nil || tc.ExpectedResult != nil {
+				var result common.Hash
+				err = json.Unmarshal(res.Result, &result)
+				require.NoError(t, err)
+				assert.Equal(t, *tc.ExpectedResult, result)
+			}
+			if res.Error != nil || tc.ExpectedError != nil {
+				assert.Equal(t, tc.ExpectedError.ErrorCode(), res.Error.Code)
+				assert.Equal(t, tc.ExpectedError.Error(), res.Error.Message)
+			}
+		})
+	}
+}
+
+func TestSendRawTransactionJSONRPCCallWithPolicyApplied(t *testing.T) {
+	// Set up the sender
+	allowedPrivateKey, err := crypto.HexToECDSA(strings.TrimPrefix("0x28b2b0318721be8c8339199172cd7cc8f5e273800a35616ec893083a4b32c02e", "0x"))
+	require.NoError(t, err)
+	allowed, err := bind.NewKeyedTransactorWithChainID(allowedPrivateKey, big.NewInt(1))
+	require.NoError(t, err)
+
+	disallowedPrivateKey, err := crypto.HexToECDSA(strings.TrimPrefix("0xdeadbeef8721be8c8339199172cd7cc8f5e273800a35616ec893083a4b32c02e", "0x"))
+	require.NoError(t, err)
+	disallowed, err := bind.NewKeyedTransactorWithChainID(disallowedPrivateKey, big.NewInt(1))
+	require.NoError(t, err)
+	require.NotNil(t, disallowed)
+
+	allowedContract := common.HexToAddress("0x1")
+	disallowedContract := common.HexToAddress("0x2")
+
+	senderDenied := types.NewRPCError(types.AccessDeniedCode, "sender disallowed send_tx by policy")
+	contractDenied := types.NewRPCError(types.AccessDeniedCode, "contract disallowed send_tx by policy")
+	deployDenied := types.NewRPCError(types.AccessDeniedCode, "sender disallowed deploy by policy")
+
+	cfg := getDefaultConfig()
+	s, m, _ := newMockedServer(t, cfg)
+	defer s.Stop()
+
+	type testCase struct {
+		Name           string
+		Input          string
+		ExpectedResult *common.Hash
+		ExpectedError  types.Error
+		Prepare        func(t *testing.T, tc *testCase)
+		SetupMocks     func(t *testing.T, m *mocksWrapper, tc testCase)
+	}
+
+	testCases := []testCase{
+		{
+			Name: "Sender & contract on allow list, accepted",
+			Prepare: func(t *testing.T, tc *testCase) {
+				tx := ethTypes.NewTransaction(1, allowedContract, big.NewInt(1), uint64(1), big.NewInt(1), []byte{})
+
+				signedTx, err := allowed.Signer(allowed.From, tx)
+				require.NoError(t, err)
+
+				txBinary, err := signedTx.MarshalBinary()
+				require.NoError(t, err)
+
+				rawTx := hex.EncodeToHex(txBinary)
+				require.NoError(t, err)
+
+				tc.Input = rawTx
+				tc.ExpectedResult = state.HashPtr(signedTx.Hash())
+				tc.ExpectedError = nil
+			},
+			SetupMocks: func(t *testing.T, m *mocksWrapper, tc testCase) {
+				m.Pool.
+					On("AddTx", context.Background(), mock.IsType(ethTypes.Transaction{}), "").
+					Return(nil).
+					Once()
+				m.Pool.
+					On("CheckPolicy", context.Background(), pool.SendTx, allowedContract).
+					Return(true, nil).
+					Once()
+				m.Pool.
+					On("CheckPolicy", context.Background(), pool.SendTx, allowed.From).
+					Return(true, nil).
+					Once()
+			},
+		},
+		{
+			Name: "Contract not on allow list, rejected",
+			Prepare: func(t *testing.T, tc *testCase) {
+				tx := ethTypes.NewTransaction(1, disallowedContract, big.NewInt(1), uint64(1), big.NewInt(1), []byte{})
+
+				signedTx, err := allowed.Signer(allowed.From, tx)
+				require.NoError(t, err)
+
+				txBinary, err := signedTx.MarshalBinary()
+				require.NoError(t, err)
+
+				rawTx := hex.EncodeToHex(txBinary)
+				require.NoError(t, err)
+
+				tc.Input = rawTx
+				tc.ExpectedResult = nil
+				tc.ExpectedError = contractDenied
+			},
+			SetupMocks: func(t *testing.T, m *mocksWrapper, tc testCase) {
+				m.Pool.
+					On("CheckPolicy", context.Background(), pool.SendTx, disallowedContract).
+					Return(false, contractDenied).
+					Once()
+			},
+		},
+		{
+			Name: "Sender not on allow list, rejected",
+			Prepare: func(t *testing.T, tc *testCase) {
+				tx := ethTypes.NewTransaction(1, allowedContract, big.NewInt(1), uint64(1), big.NewInt(1), []byte{})
+
+				signedTx, err := disallowed.Signer(disallowed.From, tx)
+				require.NoError(t, err)
+
+				txBinary, err := signedTx.MarshalBinary()
+				require.NoError(t, err)
+
+				rawTx := hex.EncodeToHex(txBinary)
+				require.NoError(t, err)
+
+				tc.Input = rawTx
+				tc.ExpectedResult = nil
+				tc.ExpectedError = senderDenied
+			},
+			SetupMocks: func(t *testing.T, m *mocksWrapper, tc testCase) {
+				m.Pool.
+					On("CheckPolicy", context.Background(), pool.SendTx, allowedContract).
+					Return(true, nil).
+					Once()
+				m.Pool.
+					On("CheckPolicy", context.Background(), pool.SendTx, disallowed.From).
+					Return(false, senderDenied).
+					Once()
+			},
+		},
+		{
+			Name: "Unsigned tx with allowed contract, accepted", // for backward compatibility
+			Prepare: func(t *testing.T, tc *testCase) {
+				tx := ethTypes.NewTransaction(1, allowedContract, big.NewInt(1), uint64(1), big.NewInt(1), []byte{})
+
+				txBinary, err := tx.MarshalBinary()
+				require.NoError(t, err)
+
+				rawTx := hex.EncodeToHex(txBinary)
+				require.NoError(t, err)
+
+				tc.Input = rawTx
+				tc.ExpectedResult = state.HashPtr(tx.Hash())
+				tc.ExpectedError = nil
+			},
+			SetupMocks: func(t *testing.T, m *mocksWrapper, tc testCase) {
+				m.Pool.
+					On("AddTx", context.Background(), mock.IsType(ethTypes.Transaction{}), "").
+					Return(nil).
+					Once()
+				// policy does not reject this case for backward compat
+			},
+		},
+		{
+			Name: "Unsigned tx with disallowed contract, rejected",
+			Prepare: func(t *testing.T, tc *testCase) {
+				tx := ethTypes.NewTransaction(1, disallowedContract, big.NewInt(1), uint64(1), big.NewInt(1), []byte{})
+
+				signedTx, err := disallowed.Signer(disallowed.From, tx)
+				require.NoError(t, err)
+
+				txBinary, err := signedTx.MarshalBinary()
+				require.NoError(t, err)
+
+				rawTx := hex.EncodeToHex(txBinary)
+				require.NoError(t, err)
+
+				tc.Input = rawTx
+				tc.ExpectedResult = nil
+				tc.ExpectedError = contractDenied
+			},
+			SetupMocks: func(t *testing.T, m *mocksWrapper, tc testCase) {
+				m.Pool.
+					On("CheckPolicy", context.Background(), pool.SendTx, disallowedContract).
+					Return(false, contractDenied).
+					Once()
+			},
+		},
+		{
+			Name: "Send invalid tx input", // for backward compatibility
+			Prepare: func(t *testing.T, tc *testCase) {
+				tc.Input = "0x1234"
+				tc.ExpectedResult = nil
+				tc.ExpectedError = types.NewRPCError(types.InvalidParamsErrorCode, "invalid tx input")
+			},
+			SetupMocks: func(t *testing.T, m *mocksWrapper, tc testCase) {},
+		},
+		{
+			Name: "Sender not on deploy allow list, rejected",
+			Prepare: func(t *testing.T, tc *testCase) {
+				deployAddr := common.HexToAddress("0x0")
+				tx := ethTypes.NewTransaction(1, deployAddr, big.NewInt(1), uint64(1), big.NewInt(1), []byte{})
+
+				signedTx, err := disallowed.Signer(disallowed.From, tx)
+				require.NoError(t, err)
+
+				txBinary, err := signedTx.MarshalBinary()
+				require.NoError(t, err)
+
+				rawTx := hex.EncodeToHex(txBinary)
+				require.NoError(t, err)
+
+				tc.Input = rawTx
+				tc.ExpectedResult = nil
+				tc.ExpectedError = deployDenied
+			},
+			SetupMocks: func(t *testing.T, m *mocksWrapper, tc testCase) {
+				m.Pool.
+					On("CheckPolicy", context.Background(), pool.Deploy, disallowed.From).
+					Return(false, nil).
+					Once()
+			},
 		},
 	}
 

--- a/jsonrpc/mocks/mock_pool.go
+++ b/jsonrpc/mocks/mock_pool.go
@@ -35,6 +35,30 @@ func (_m *PoolMock) AddTx(ctx context.Context, tx types.Transaction, ip string) 
 	return r0
 }
 
+// CheckPolicy provides a mock function with given fields: ctx, policy, address
+func (_m *PoolMock) CheckPolicy(ctx context.Context, policy pool.PolicyName, address common.Address) (bool, error) {
+	ret := _m.Called(ctx, policy, address)
+
+	var r0 bool
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, pool.PolicyName, common.Address) (bool, error)); ok {
+		return rf(ctx, policy, address)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, pool.PolicyName, common.Address) bool); ok {
+		r0 = rf(ctx, policy, address)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, pool.PolicyName, common.Address) error); ok {
+		r1 = rf(ctx, policy, address)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // CountPendingTransactions provides a mock function with given fields: ctx
 func (_m *PoolMock) CountPendingTransactions(ctx context.Context) (uint64, error) {
 	ret := _m.Called(ctx)

--- a/jsonrpc/policy.go
+++ b/jsonrpc/policy.go
@@ -1,0 +1,61 @@
+package jsonrpc
+
+import (
+	"context"
+
+	"github.com/0xPolygon/supernets2-node/jsonrpc/types"
+	"github.com/0xPolygon/supernets2-node/pool"
+	"github.com/0xPolygon/supernets2-node/state"
+	"github.com/ethereum/go-ethereum/common"
+	ethTypes "github.com/ethereum/go-ethereum/core/types"
+)
+
+func checkPolicy(ctx context.Context, p types.PoolInterface, input string) error {
+	tx, err := hexToTx(input)
+	if err != nil {
+		// ignore it, let the later processing reject
+		return nil
+	}
+
+	// if the tx is signed, check the from address. If there is no from address, the tx is not rejected as it
+	// will get rejected later. This maintains backward compatibility with RPC expectations. TODO: verify this is ok behavior
+	var from common.Address
+	if from, err = state.GetSender(*tx); err != nil {
+		// if not signed, then skip check, it fails later on its own
+		return nil
+	}
+
+	switch resolvePolicy(tx) {
+	case pool.SendTx:
+		var allow bool
+		if allow, err = p.CheckPolicy(ctx, pool.SendTx, *tx.To()); err != nil {
+			return err
+		}
+		if !allow {
+			return pool.ErrContractDisallowedSendTx
+		}
+		if allow, err = p.CheckPolicy(ctx, pool.SendTx, from); err != nil {
+			return err
+		}
+		if !allow {
+			return pool.ErrSenderDisallowedSendTx
+		}
+	case pool.Deploy:
+		var allow bool
+		// check that sender may deploy contracts
+		if allow, err = p.CheckPolicy(ctx, pool.Deploy, from); err != nil {
+			return err
+		}
+		if !allow {
+			return pool.ErrSenderDisallowedDeploy
+		}
+	}
+	return nil
+}
+
+func resolvePolicy(tx *ethTypes.Transaction) pool.PolicyName {
+	if tx.To() == nil || tx.To().Hex() == common.HexToAddress("0x0").Hex() {
+		return pool.Deploy
+	}
+	return pool.SendTx
+}

--- a/jsonrpc/types/errors.go
+++ b/jsonrpc/types/errors.go
@@ -15,6 +15,8 @@ const (
 	InvalidParamsErrorCode = -32602
 	// ParserErrorCode error code for parsing errors
 	ParserErrorCode = -32700
+	// AccessDeniedCode error code when requests are denied
+	AccessDeniedCode = -32800
 )
 
 // Error interface

--- a/jsonrpc/types/interfaces.go
+++ b/jsonrpc/types/interfaces.go
@@ -22,6 +22,7 @@ type PoolInterface interface {
 	GetPendingTxs(ctx context.Context, limit uint64) ([]pool.Transaction, error)
 	CountPendingTransactions(ctx context.Context) (uint64, error)
 	GetTxByHash(ctx context.Context, hash common.Hash) (*pool.Transaction, error)
+	CheckPolicy(ctx context.Context, policy pool.PolicyName, address common.Address) (bool, error)
 }
 
 // StateInterface gathers the methods required to interact with the state.

--- a/pool/errors.go
+++ b/pool/errors.go
@@ -64,4 +64,13 @@ var (
 
 	// ErrGasPrice is returned if the transaction has specified lower gas price than the minimum allowed.
 	ErrGasPrice = errors.New("gas price too low")
+
+	// ErrSenderDisallowedSendTx is returned when transactions by sender are is disallowed by policy
+	ErrSenderDisallowedSendTx = errors.New("sender disallowed send_tx by policy")
+
+	// ErrContractDisallowedSendTx is returned when transactions to contract are is disallowed by policy
+	ErrContractDisallowedSendTx = errors.New("contract disallowed send_tx by policy")
+
+	// ErrSenderDisallowedDeploy is returned when deploy transactions are disallowed by policy
+	ErrSenderDisallowedDeploy = errors.New("sender disallowed deploy by policy")
 )

--- a/pool/interfaces.go
+++ b/pool/interfaces.go
@@ -36,6 +36,7 @@ type storage interface {
 	MarkWIPTxsAsPending(ctx context.Context) error
 	GetAllAddressesBlocked(ctx context.Context) ([]common.Address, error)
 	MinL2GasPriceSince(ctx context.Context, timestamp time.Time) (uint64, error)
+	CheckPolicy(ctx context.Context, policy PolicyName, address common.Address) (bool, error)
 }
 
 type stateInterface interface {

--- a/pool/policy.go
+++ b/pool/policy.go
@@ -1,0 +1,11 @@
+package pool
+
+// PolicyName is a named policy
+type PolicyName string
+
+const (
+	// SendTx is the name of the policy that governs that an address may send transactions to pool
+	SendTx PolicyName = "send_tx"
+	// Deploy is the name of the policy that governs that an address may deploy a contract
+	Deploy PolicyName = "deploy"
+)

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -303,6 +303,11 @@ func (p *Pool) IsTxPending(ctx context.Context, hash common.Hash) (bool, error) 
 	return p.storage.IsTxPending(ctx, hash)
 }
 
+// CheckPolicy checks if an address is allowed by policy name
+func (p *Pool) CheckPolicy(ctx context.Context, policy PolicyName, address common.Address) (bool, error) {
+	return p.storage.CheckPolicy(ctx, policy, address)
+}
+
 func (p *Pool) validateTx(ctx context.Context, poolTx Transaction) error {
 	// Make sure the transaction is signed properly.
 	if err := state.CheckSignature(poolTx.Transaction); err != nil {

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -1787,6 +1787,67 @@ func Test_AddTx_NonceTooHigh(t *testing.T) {
 	require.Error(t, err, pool.ErrNonceTooHigh)
 }
 
+func Test_PolicyAcl(t *testing.T) {
+
+	initOrResetDB(t)
+
+	poolSqlDB, err := db.NewSQLDB(poolDBCfg)
+	require.NoError(t, err)
+	defer poolSqlDB.Close() //nolint:gosec,errcheck
+
+	ctx := context.Background()
+	s, err := pgpoolstorage.NewPostgresPoolStorage(poolDBCfg)
+	require.NoError(t, err)
+
+	p := pool.NewPool(cfg, s, nil, uint64(1), nil)
+
+	addr1 := common.HexToAddress("0x1")
+	addr2 := common.HexToAddress("0x2")
+	addr3 := common.HexToAddress("0x3")
+
+	for _, policy := range []pool.PolicyName{pool.SendTx, pool.Deploy} {
+		allow, err := p.CheckPolicy(ctx, policy, addr1)
+		require.NoError(t, err)
+		require.True(t, allow) // default is to allow
+	}
+
+	// put addr on lists
+	for _, policy := range []pool.PolicyName{pool.SendTx, pool.Deploy} {
+		ctag, err := poolSqlDB.Exec(ctx, "INSERT INTO pool.acl (policy, address) VALUES ($1,$2)", policy, addr1.Hex())
+		require.NoError(t, err)
+		require.Equal(t, int64(1), ctag.RowsAffected())
+	}
+
+	// list members are now denied
+	for _, policy := range []pool.PolicyName{pool.SendTx, pool.Deploy} {
+		allow, err := p.CheckPolicy(ctx, policy, addr1)
+		require.NoError(t, err)
+		require.False(t, allow) // default is to allow
+	}
+
+	// change policies to deny by default
+	ctag, err := poolSqlDB.Exec(ctx, "UPDATE pool.policy SET allow = false")
+	require.NoError(t, err)
+	require.Equal(t, int64(2), ctag.RowsAffected())
+
+	// list members are now allowed
+	for _, policy := range []pool.PolicyName{pool.SendTx, pool.Deploy} {
+		allow, err := p.CheckPolicy(ctx, policy, addr1)
+		require.NoError(t, err)
+		require.True(t, allow)
+	}
+
+	// randos are now denied
+	for _, policy := range []pool.PolicyName{pool.SendTx, pool.Deploy} {
+		for _, a := range []common.Address{addr2, addr3} {
+			allow, err := s.CheckPolicy(ctx, policy, a)
+			require.NoError(t, err)
+			require.False(t, allow)
+		}
+	}
+
+}
+
 func setupPool(t *testing.T, cfg pool.Config, s *pgpoolstorage.PostgresPoolStorage, st *state.State, chainID uint64, ctx context.Context, eventLog *event.EventLog) *pool.Pool {
 	p := pool.NewPool(cfg, s, st, chainID, eventLog)
 

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -1788,7 +1788,6 @@ func Test_AddTx_NonceTooHigh(t *testing.T) {
 }
 
 func Test_PolicyAcl(t *testing.T) {
-
 	initOrResetDB(t)
 
 	poolSqlDB, err := db.NewSQLDB(poolDBCfg)
@@ -1845,7 +1844,6 @@ func Test_PolicyAcl(t *testing.T) {
 			require.False(t, allow)
 		}
 	}
-
 }
 
 func setupPool(t *testing.T, cfg pool.Config, s *pgpoolstorage.PostgresPoolStorage, st *state.State, chainID uint64, ctx context.Context, eventLog *event.EventLog) *pool.Pool {


### PR DESCRIPTION
This PR adds policy and acl tables to the pool db which define allow/deny list semantics to sending transactions and deploying contracts. 

- in sendRawTransaction, the transaction is classified as a `send_tx` or a `deploy` transaction
- The policy with the resolved name is queried along with the `from` or `to` address (which ever is relevant)
- if the address is on the list, it gets the opposite `allow` setting of the policy
- disallowed requests receive access denied error 

Unsigned transactions are ignored for backward compatibility since they get rejected later anyway.