### PR TITLE
Allow List CLI

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -186,6 +186,7 @@ func main() {
 			Action:  restore,
 			Flags:   restoreFlags,
 		},
+		&policyCommands,
 	}
 
 	err := app.Run(os.Args)

--- a/cmd/policy.go
+++ b/cmd/policy.go
@@ -53,30 +53,30 @@ var policyCommands = cli.Command{
 	Flags:  []cli.Flag{&configFileFlag},
 	Subcommands: []*cli.Command{
 		{
-			Name:   "update",
-			Usage:  "Update the default action for a policy",
-			Action: updatePolicy,
-			Flags:  append(policyActionFlags, &allowFlag, &denyFlag),
-		}, {
-			Name:   "describe",
-			Usage:  "Describe the default actions for the policies",
-			Action: describe,
-			Flags:  append(policyActionFlags, &noHeaderFlag),
-		}, {
 			Name:   "add",
 			Usage:  "Add address(es) to a policy exclusion list",
 			Action: addAcl,
-			Flags:  append(policyActionFlags, &csvFlag),
-		}, {
-			Name:   "remove",
-			Usage:  "Remove address(es) from a policy exclusion list",
-			Action: removeAcl,
 			Flags:  append(policyActionFlags, &csvFlag),
 		}, {
 			Name:   "clear",
 			Usage:  "Clear the addresses listed as exceptions to a policy",
 			Action: clearAcl,
 			Flags:  policyActionFlags,
+		}, {
+			Name:   "describe",
+			Usage:  "Describe the default actions for the policies",
+			Action: describe,
+			Flags:  append(policyActionFlags, &noHeaderFlag),
+		}, {
+			Name:   "remove",
+			Usage:  "Remove address(es) from a policy exclusion list",
+			Action: removeAcl,
+			Flags:  append(policyActionFlags, &csvFlag),
+		}, {
+			Name:   "update",
+			Usage:  "Update the default action for a policy",
+			Action: updatePolicy,
+			Flags:  append(policyActionFlags, &allowFlag, &denyFlag),
 		},
 	},
 }

--- a/cmd/policy.go
+++ b/cmd/policy.go
@@ -1,0 +1,280 @@
+package main
+
+import (
+	"context"
+	"encoding/csv"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/0xPolygonHermez/zkevm-node/config"
+	"github.com/0xPolygonHermez/zkevm-node/pool"
+	"github.com/0xPolygonHermez/zkevm-node/pool/pgpoolstorage"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/urfave/cli/v2"
+)
+
+var (
+	policyFlag = cli.StringFlag{
+		Name:     "policy",
+		Aliases:  []string{"p"},
+		Usage:    "Name of policy to operate on",
+		Required: true,
+	}
+	csvFlag = cli.StringFlag{
+		Name:     "csv",
+		Usage:    "CSV file with addresses",
+		Required: false,
+	}
+	allowFlag = cli.BoolFlag{
+		Name:     "allow",
+		Usage:    "Update policy action to allow/deny by default",
+		Required: false,
+	}
+
+	policyActionFlags = []cli.Flag{&policyFlag}
+)
+
+var policyCommands = cli.Command{
+	Name:   "policy",
+	Usage:  "View, update, and apply policies",
+	Action: describePolicies,
+	Flags:  []cli.Flag{&configFileFlag},
+	Subcommands: []*cli.Command{
+		{
+			Name:   "update",
+			Usage:  "Update the default action for a policy",
+			Action: updatePolicy,
+			Flags:  append(policyActionFlags, &allowFlag),
+		}, {
+			Name:   "describe",
+			Usage:  "Describe the default actions for the policies",
+			Action: describePolicies,
+		}, {
+			Name:   "add",
+			Usage:  "Add address(es) to a policy exclusion list",
+			Action: addAcl,
+			Flags:  append(policyActionFlags, &csvFlag),
+		}, {
+			Name:   "remove",
+			Usage:  "Remove address(es) from a policy exclusion list",
+			Action: removeAcl,
+			Flags:  append(policyActionFlags, &csvFlag),
+		}, {
+			Name:   "clear",
+			Usage:  "Clear the addresses listed as exceptions to a policy",
+			Action: clearAcl,
+			Flags:  policyActionFlags,
+		}, {
+			Name:   "list",
+			Usage:  "List the state and address exclusion list for a policy",
+			Action: listAcl,
+			Flags:  policyActionFlags,
+		},
+	},
+}
+
+func describePolicies(cli *cli.Context) error {
+	_, db, err := configAndStorage(cli)
+	if err != nil {
+		return err
+	}
+	list, err := db.DescribePolicies(context.Background())
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("%7s: %s\n", "Policy", "Default")
+	for _, p := range list {
+		fmt.Printf("%7s: %s\n", p.Name, p.Desc())
+	}
+
+	return nil
+}
+
+func updatePolicy(cli *cli.Context) error {
+	_, db, err := configAndStorage(cli)
+	if err != nil {
+		return err
+	}
+	policy, err := resolvePolicy(cli)
+	if err != nil {
+		return err
+	}
+	var allow = true
+	if !cli.IsSet("allow") {
+		return errors.New("supply one policy action [--allow=true or --allow=false]")
+	}
+	allow = cli.Bool("allow")
+	err = db.UpdatePolicy(context.Background(), policy, allow)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func addAcl(cli *cli.Context) error {
+	_, db, err := configAndStorage(cli)
+	if err != nil {
+		return err
+	}
+	policy, addresses, err := requirePolicyAndAddresses(cli)
+	if err != nil {
+		return err
+	}
+	err = db.AddAddressesToPolicy(context.Background(), policy, addresses)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func removeAcl(cli *cli.Context) error {
+	_, db, err := configAndStorage(cli)
+	if err != nil {
+		return err
+	}
+	policy, addresses, err := requirePolicyAndAddresses(cli)
+	if err != nil {
+		return err
+	}
+	err = db.RemoveAddressesFromPolicy(context.Background(), policy, addresses)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func clearAcl(cli *cli.Context) error {
+	_, db, err := configAndStorage(cli)
+	if err != nil {
+		return err
+	}
+	policy, err := resolvePolicy(cli)
+	if err != nil {
+		return err
+	}
+	err = db.ClearPolicy(context.Background(), policy)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func listAcl(cli *cli.Context) error {
+	_, db, err := configAndStorage(cli)
+	if err != nil {
+		return err
+	}
+	policyName, err := resolvePolicy(cli)
+	if err != nil {
+		return err
+	}
+
+	policy, err := db.DescribePolicy(context.Background(), policyName)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("%s: %s\n", "Policy", policy.Name)
+	fmt.Printf("%s: %s\n", "Default", policy.Desc())
+
+	query, err := resolveAddresses(cli, false)
+	if err != nil {
+		return nil
+	}
+	list, err := db.ListAcl(context.Background(), policyName, query)
+	if err != nil {
+		return err
+	}
+	listAction := "Denied"
+	if !policy.Allow {
+		listAction = "Allowed"
+	}
+	fmt.Printf("%s addrs:\n", listAction)
+	for _, address := range list {
+		fmt.Println(address.Hex())
+	}
+	return nil
+}
+
+func configAndStorage(cli *cli.Context) (*config.Config, *pgpoolstorage.PostgresPoolStorage, error) {
+	c, err := config.Load(cli, false)
+	if err != nil {
+		return nil, nil, err
+	}
+	setupLog(c.Log)
+
+	db, err := pgpoolstorage.NewPostgresPoolStorage(c.Pool.DB)
+	if err != nil {
+		return nil, nil, err
+	}
+	return c, db, nil
+}
+
+func requirePolicyAndAddresses(cli *cli.Context) (pool.PolicyName, []common.Address, error) {
+	policy, err := resolvePolicy(cli)
+	if err != nil {
+		return "", nil, err
+	}
+	addresses, err := resolveAddresses(cli, true)
+	if err != nil {
+		return "", nil, err
+	}
+	return policy, addresses, nil
+}
+
+func resolvePolicy(cli *cli.Context) (pool.PolicyName, error) {
+	policy := cli.String("policy")
+	if policy == "" {
+		return "", nil
+	}
+	if !pool.IsPolicy(policy) {
+		return "", fmt.Errorf("invalid policy name: %s", policy)
+	}
+	return pool.PolicyName(policy), nil
+}
+
+func resolveAddresses(cli *cli.Context, failIfEmpty bool) ([]common.Address, error) {
+	var set = make(map[common.Address]struct{})
+	if cli.IsSet("csv") {
+		file := cli.String("csv")
+		fd, err := os.Open(file)
+		if err != nil {
+			return nil, err
+		}
+		defer func(fd *os.File) {
+			_ = fd.Close()
+		}(fd)
+
+		fileReader := csv.NewReader(fd)
+		records, err := fileReader.ReadAll()
+
+		if err != nil {
+			return nil, err
+		}
+		for _, row := range records {
+			for _, cell := range row {
+				hex := strings.TrimSpace(cell)
+				set[common.HexToAddress(hex)] = struct{}{}
+			}
+		}
+	}
+
+	for _, a := range cli.Args().Slice() {
+		a = strings.TrimSpace(a)
+		a = strings.Trim(a, ",|")
+		if !strings.HasPrefix(a, "0x") {
+			a = "0x" + a
+		}
+		set[common.HexToAddress(a)] = struct{}{}
+	}
+	var ret []common.Address
+	for a := range set {
+		ret = append(ret, a)
+	}
+	if failIfEmpty && len(ret) == 0 {
+		return nil, errors.New("no addresses given")
+	}
+	return ret, nil
+}

--- a/cmd/policy.go
+++ b/cmd/policy.go
@@ -102,11 +102,10 @@ func updatePolicy(cli *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	var allow = true
 	if !cli.IsSet("allow") {
 		return errors.New("supply one policy action [--allow=true or --allow=false]")
 	}
-	allow = cli.Bool("allow")
+	allow := cli.Bool("allow")
 	err = db.UpdatePolicy(context.Background(), policy, allow)
 	if err != nil {
 		return err

--- a/db/migrations/pool/supernets-0001.sql
+++ b/db/migrations/pool/supernets-0001.sql
@@ -9,8 +9,8 @@ CREATE TABLE pool.policy
     allow BOOLEAN NOT NULL DEFAULT false
 );
 
-INSERT INTO pool.policy (name, allow) VALUES ('send_tx', true);
-INSERT INTO pool.policy (name, allow) VALUES ('deploy', true);
+INSERT INTO pool.policy (name, allow) VALUES ('send_tx', false);
+INSERT INTO pool.policy (name, allow) VALUES ('deploy', false);
 
 CREATE TABLE pool.acl
 (

--- a/pool/interfaces.go
+++ b/pool/interfaces.go
@@ -36,7 +36,17 @@ type storage interface {
 	MarkWIPTxsAsPending(ctx context.Context) error
 	GetAllAddressesBlocked(ctx context.Context) ([]common.Address, error)
 	MinL2GasPriceSince(ctx context.Context, timestamp time.Time) (uint64, error)
+	policy
+}
+
+type policy interface {
 	CheckPolicy(ctx context.Context, policy PolicyName, address common.Address) (bool, error)
+	AddAddressesToPolicy(ctx context.Context, policy PolicyName, addresses []common.Address) error
+	RemoveAddressesFromPolicy(ctx context.Context, policy PolicyName, addresses []common.Address) error
+	ClearPolicy(ctx context.Context, policy PolicyName) error
+	DescribePolicies(ctx context.Context) ([]Policy, error)
+	DescribePolicy(ctx context.Context, name PolicyName) (Policy, error)
+	ListAcl(ctx context.Context, policy PolicyName, query []common.Address) ([]common.Address, error)
 }
 
 type stateInterface interface {

--- a/pool/pgpoolstorage/pgpoolstorage.go
+++ b/pool/pgpoolstorage/pgpoolstorage.go
@@ -732,38 +732,3 @@ func (p *PostgresPoolStorage) GetAllAddressesBlocked(ctx context.Context) ([]com
 
 	return addrs, nil
 }
-
-// CheckPolicy returns the rule for the policy if the address is not associated with the rule (default), or the opposite
-// of the rule if it is. This allows the rule to act as an allow or deny list.
-func (p *PostgresPoolStorage) CheckPolicy(ctx context.Context, policy pool.PolicyName, address common.Address) (bool, error) {
-	sql := `SELECT 
-				CASE WHEN a.address is null THEN 
-					p.allow 
-				ELSE 
-					NOT p.allow 
-				END 
-			FROM pool.policy p 
-				LEFT JOIN pool.acl a 
-					ON p.name = a.policy 
-					AND a.address = $1 
-			WHERE p.name = $2`
-
-	args := []interface{}{address.Hex(), policy}
-	rows, err := p.db.Query(ctx, sql, args...)
-
-	if errors.Is(err, pgx.ErrNoRows) {
-		return false, pool.ErrNotFound
-	} else if err != nil {
-		return false, err
-	}
-	if !rows.Next() { // should always be a row if the policy exists
-		return false, nil
-	}
-
-	var allow bool
-	err = rows.Scan(&allow)
-	if err != nil {
-		return false, err
-	}
-	return allow, nil
-}

--- a/pool/pgpoolstorage/policy.go
+++ b/pool/pgpoolstorage/policy.go
@@ -1,0 +1,192 @@
+package pgpoolstorage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/0xPolygonHermez/zkevm-node/pool"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/jackc/pgx/v4"
+)
+
+// CheckPolicy returns the rule for the policy if the address is not associated with the rule (default), or the opposite
+// of the rule if it is. This allows the rule to act as an allow or deny list.
+func (p *PostgresPoolStorage) CheckPolicy(ctx context.Context, policy pool.PolicyName, address common.Address) (bool, error) {
+	sql := `SELECT 
+				CASE WHEN a.address is null THEN 
+					p.allow 
+				ELSE 
+					NOT p.allow 
+				END 
+			FROM pool.policy p 
+				LEFT JOIN pool.acl a 
+					ON p.name = a.policy 
+					AND a.address = $1 
+			WHERE p.name = $2`
+
+	rows, err := p.db.Query(ctx, sql, address.Hex(), policy)
+
+	if errors.Is(err, pgx.ErrNoRows) {
+		return false, pool.ErrNotFound
+	} else if err != nil {
+		return false, err
+	}
+	if !rows.Next() { // should always be a row if the policy exists
+		return false, nil
+	}
+
+	var allow bool
+	err = rows.Scan(&allow)
+	if err != nil {
+		return false, err
+	}
+	return allow, nil
+}
+
+func (p *PostgresPoolStorage) UpdatePolicy(ctx context.Context, policy pool.PolicyName, allow bool) error {
+	sql := "UPDATE pool.policy SET allow = $1 WHERE name = $2"
+	_, err := p.db.Exec(ctx, sql, allow, string(policy))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *PostgresPoolStorage) AddAddressesToPolicy(ctx context.Context, policy pool.PolicyName, addresses []common.Address) error {
+	sql := "INSERT INTO pool.acl (policy, address) VALUES ($1, $2) ON CONFLICT DO NOTHING"
+	tx, err := p.db.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func(tx pgx.Tx, ctx context.Context) {
+		_ = tx.Rollback(ctx)
+	}(tx, ctx)
+
+	for _, a := range addresses {
+		_, err = tx.Exec(ctx, sql, policy, a.Hex())
+		if err != nil {
+			return err
+		}
+	}
+	err = tx.Commit(ctx)
+	if err != nil {
+		return nil
+	}
+	return nil
+}
+
+func (p *PostgresPoolStorage) RemoveAddressesFromPolicy(ctx context.Context, policy pool.PolicyName, addresses []common.Address) error {
+	sql := "DELETE FROM pool.acl WHERE policy = $1 AND address = $2"
+	tx, err := p.db.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func(tx pgx.Tx, ctx context.Context) {
+		_ = tx.Rollback(ctx)
+	}(tx, ctx)
+
+	for _, a := range addresses {
+		_, err = tx.Exec(ctx, sql, policy, a.Hex())
+		if err != nil {
+			return err
+		}
+	}
+	err = tx.Commit(ctx)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *PostgresPoolStorage) ClearPolicy(ctx context.Context, policy pool.PolicyName) error {
+	sql := "DELETE FROM pool.acl WHERE policy = $1"
+	_, err := p.db.Exec(ctx, sql, policy)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *PostgresPoolStorage) DescribePolicies(ctx context.Context) ([]pool.Policy, error) {
+	sql := "SELECT name, allow FROM pool.policy"
+	rows, err := p.db.Query(ctx, sql)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		} else {
+			return nil, err
+		}
+	}
+	defer rows.Close()
+
+	var list []pool.Policy
+	for rows.Next() {
+		var name string
+		var allow bool
+		err = rows.Scan(&name, &allow)
+		if err != nil {
+			return nil, err
+		}
+		if pool.IsPolicy(name) { // skip unknown
+			p := pool.Policy{
+				Name:  pool.PolicyName(name),
+				Allow: allow,
+			}
+			list = append(list, p)
+		}
+	}
+	return list, nil
+}
+
+func (p *PostgresPoolStorage) DescribePolicy(ctx context.Context, name pool.PolicyName) (pool.Policy, error) {
+	sql := "SELECT name, allow FROM pool.policy WHERE name = $1 LIMIT 1"
+	row := p.db.QueryRow(ctx, sql, name)
+	var (
+		pName string
+		allow bool
+	)
+	err := row.Scan(&pName, &allow)
+	if err != nil {
+		return pool.Policy{}, err
+	}
+	return pool.Policy{
+		Name:  pool.PolicyName(pName),
+		Allow: allow,
+	}, nil
+}
+
+func (p *PostgresPoolStorage) ListAcl(
+	ctx context.Context, policy pool.PolicyName, query []common.Address) ([]common.Address, error) {
+	sql := "SELECT address FROM pool.acl WHERE policy = $1"
+
+	if len(query) > 0 {
+		var addrs []string
+		for _, a := range query {
+			addrs = append(addrs, a.Hex())
+		}
+		sql = sql + fmt.Sprintf(" IN (%v)", strings.Join(addrs, ","))
+	}
+
+	rows, err := p.db.Query(ctx, sql, string(policy))
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		} else {
+			return nil, err
+		}
+	}
+	defer rows.Close()
+
+	var addresses []common.Address
+	for rows.Next() {
+		var addr string
+		err = rows.Scan(&addr)
+		if err != nil {
+			return nil, err
+		}
+		addresses = append(addresses, common.HexToAddress(addr))
+	}
+	return addresses, nil
+}

--- a/pool/pgpoolstorage/policy.go
+++ b/pool/pgpoolstorage/policy.go
@@ -45,6 +45,7 @@ func (p *PostgresPoolStorage) CheckPolicy(ctx context.Context, policy pool.Polic
 	return allow, nil
 }
 
+// UpdatePolicy sets the default action for the named policy
 func (p *PostgresPoolStorage) UpdatePolicy(ctx context.Context, policy pool.PolicyName, allow bool) error {
 	sql := "UPDATE pool.policy SET allow = $1 WHERE name = $2"
 	_, err := p.db.Exec(ctx, sql, allow, string(policy))
@@ -54,6 +55,7 @@ func (p *PostgresPoolStorage) UpdatePolicy(ctx context.Context, policy pool.Poli
 	return nil
 }
 
+// AddAddressesToPolicy adds address ACLs to the named policy. Their policies will be the opposite of the default action.
 func (p *PostgresPoolStorage) AddAddressesToPolicy(ctx context.Context, policy pool.PolicyName, addresses []common.Address) error {
 	sql := "INSERT INTO pool.acl (policy, address) VALUES ($1, $2) ON CONFLICT DO NOTHING"
 	tx, err := p.db.Begin(ctx)
@@ -77,6 +79,7 @@ func (p *PostgresPoolStorage) AddAddressesToPolicy(ctx context.Context, policy p
 	return nil
 }
 
+// RemoveAddressesFromPolicy removes addresses from the named policy ACL
 func (p *PostgresPoolStorage) RemoveAddressesFromPolicy(ctx context.Context, policy pool.PolicyName, addresses []common.Address) error {
 	sql := "DELETE FROM pool.acl WHERE policy = $1 AND address = $2"
 	tx, err := p.db.Begin(ctx)
@@ -100,6 +103,7 @@ func (p *PostgresPoolStorage) RemoveAddressesFromPolicy(ctx context.Context, pol
 	return nil
 }
 
+// ClearPolicy removes _all_ addresses from the policy ACL
 func (p *PostgresPoolStorage) ClearPolicy(ctx context.Context, policy pool.PolicyName) error {
 	sql := "DELETE FROM pool.acl WHERE policy = $1"
 	_, err := p.db.Exec(ctx, sql, policy)
@@ -109,6 +113,7 @@ func (p *PostgresPoolStorage) ClearPolicy(ctx context.Context, policy pool.Polic
 	return nil
 }
 
+// DescribePolicies displays the current state of the named policies
 func (p *PostgresPoolStorage) DescribePolicies(ctx context.Context) ([]pool.Policy, error) {
 	sql := "SELECT name, allow FROM pool.policy"
 	rows, err := p.db.Query(ctx, sql)
@@ -140,6 +145,7 @@ func (p *PostgresPoolStorage) DescribePolicies(ctx context.Context) ([]pool.Poli
 	return list, nil
 }
 
+// DescribePolicy displays the current state of the named policy and addresses associated
 func (p *PostgresPoolStorage) DescribePolicy(ctx context.Context, name pool.PolicyName) (pool.Policy, error) {
 	sql := "SELECT name, allow FROM pool.policy WHERE name = $1 LIMIT 1"
 	row := p.db.QueryRow(ctx, sql, name)
@@ -157,6 +163,7 @@ func (p *PostgresPoolStorage) DescribePolicy(ctx context.Context, name pool.Poli
 	}, nil
 }
 
+// ListAcl lists the addresses associated with the policy's exclusion list
 func (p *PostgresPoolStorage) ListAcl(
 	ctx context.Context, policy pool.PolicyName, query []common.Address) ([]common.Address, error) {
 	sql := "SELECT address FROM pool.acl WHERE policy = $1"

--- a/pool/policy.go
+++ b/pool/policy.go
@@ -1,5 +1,7 @@
 package pool
 
+import "github.com/ethereum/go-ethereum/common"
+
 // PolicyName is a named policy
 type PolicyName string
 
@@ -9,3 +11,33 @@ const (
 	// Deploy is the name of the policy that governs that an address may deploy a contract
 	Deploy PolicyName = "deploy"
 )
+
+// Policy describes state of a named policy
+type Policy struct {
+	Name  PolicyName
+	Allow bool
+}
+
+// Desc returns the string representation of a policy rule
+func (p *Policy) Desc() string {
+	if p.Allow {
+		return "allow"
+	}
+	return "deny"
+}
+
+// Acl describes exception to a named Policy by address
+type Acl struct {
+	PolicyName PolicyName
+	Address    common.Address
+}
+
+// IsPolicy tests if a string represents a known named Policy
+func IsPolicy(name string) bool {
+	for _, p := range []PolicyName{SendTx, Deploy} {
+		if name == string(p) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
This PR adds a cli interface for view/update allow/deny policies.

Policies have an allow/deny setting. If an address is on it's list, it is allowed/denied according to policy. If an address is not on the policy's list, it gets the opposite of the setting. 

A policy with allow=true is an 'allow list' - addresses on the list are allowed, all others are denied.

A policy with allow=false is a 'deny list' - addresses on the list are denied, all others are allowed.

```shell                                                                                        $ dist/supernets2-node policy --help                                                                                          

NAME:
   supernets2-node policy - View, update, and apply policies

USAGE:
   supernets2-node policy command [command options] [arguments...]

COMMANDS:
   update    Update the default action for a policy
   describe  Describe the default actions for the policies
   add       Add address(es) to a policy exclusion list
   remove    Remove address(es) from a policy exclusion list
   clear     Clear the addresses listed as exceptions to a policy
   help, h   Shows a list of commands or help for one command

OPTIONS:
   --cfg FILE, -c FILE  Configuration FILE
   --help, -h           show help
```