### PR TITLE
Fix wrong image names in docker-compose.yml

### DIFF
--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -224,7 +224,7 @@ services:
 
   cdk-validium-explorer-l1:
     container_name: cdk-validium-explorer-l1
-    image: hermeznetwork/hermez-node-blockscout:latest
+    image: hermeznetwork/zkevm-explorer:latest
     ports:
       - 4000:4000
     environment:
@@ -257,7 +257,7 @@ services:
 
   cdk-validium-explorer-l2:
     container_name: cdk-validium-explorer-l2
-    image: hermeznetwork/hermez-node-blockscout:latest
+    image: hermeznetwork/zkevm-explorer:latest
     ports:
       - 4001:4000
     environment:


### PR DESCRIPTION
the `hermeznetwork/hermez-node-blockscout` image doesn't exist anymore

more context: https://github.com/0xPolygonHermez/zkevm-node/pull/2060

it's werid that this was not picked into the cdk repo