### PR TITLE
fix: set BatchRequestsEnabled in test node config

### DIFF
--- a/test/config/debug.node.config.toml
+++ b/test/config/debug.node.config.toml
@@ -71,6 +71,7 @@ WriteTimeout = "60s"
 MaxRequestsPerIPAndSecond = 10000
 SequencerNodeURI = ""
 EnableL2SuggestedGasPricePolling = true
+BatchRequestsEnabled = true
 	[RPC.WebSockets]
 		Enabled = true
 		Port = 8133

--- a/test/config/test.node.config.toml
+++ b/test/config/test.node.config.toml
@@ -71,6 +71,7 @@ WriteTimeout = "60s"
 MaxRequestsPerIPAndSecond = 5000
 SequencerNodeURI = ""
 EnableL2SuggestedGasPricePolling = true
+BatchRequestsEnabled = true
 	[RPC.WebSockets]
 		Enabled = true
 		Port = 8133


### PR DESCRIPTION
by default, this flag is set to `false`. This prevents the block explorer from sending batch requests to the RPC for indexing

after this, we won't see issues like https://github.com/0xPolygon/cdk-validium-node/issues/50