### PR TITLE
Fix deploy-sc overdraft error

### DIFF
--- a/test/scripts/deploy_sc/main.go
+++ b/test/scripts/deploy_sc/main.go
@@ -133,14 +133,6 @@ func main() {
 		to := common.HexToAddress(receiverAddr)
 		tx = ethTransfer(ctx, client, auth, to, transferAmount, nil)
 		fmt.Println()
-
-		// Invalid ETH Transfer
-		log.Debugf("Sending Invalid TX to transfer ETH")
-		nonce := tx.Nonce() + 1
-		ethTransfer(ctx, client, auth, to, transferAmount, &nonce)
-		err = operations.WaitTxToBeMined(ctx, client, tx, txTimeout)
-		chkErr(err)
-		fmt.Println()
 	}
 }
 


### PR DESCRIPTION
Related to https://github.com/0xPolygonHermez/zkevm-node/pull/3110

### What does this PR do?

> Removes `Invalid ETH Transfer` from `/test/scripts/deploy_sc/main.go`

As @ToniRamirezM mentioned in his comment https://github.com/0xPolygonHermez/zkevm-node/issues/2399#issuecomment-1683465828, https://github.com/ethereum/go-ethereum added a check to ensure transactions aren't overdraft before submitting. The issue opened to add a flag to control this feature (https://github.com/ethereum/go-ethereum/issues/27274) was closed.

This PR removes the test for invalid (overdraft) tx altogether to avoid a fatal error while running `make deploy-sc`
