### PR TITLE
Fix genesisBlockNumber

### DIFF
--- a/test/config/test.genesis.config.json
+++ b/test/config/test.genesis.config.json
@@ -7,7 +7,7 @@
     "cdkDataCommitteeContract": "0x2279B7A0a67DB372996a5FaB50D91eAA73d2eBe6"
 	},
   "root": "0xd88680f1b151dd67518f9aca85161424c0cac61df2f5424a3ddc04ea25adecc7",
-  "genesisBlockNumber": 75,
+  "genesisBlockNumber": 76,
   "genesis": [
    {
     "contractName": "PolygonZkEVMDeployer",


### PR DESCRIPTION
Correct `genesisBlockNumber` for fix #47 

![CleanShot 2024-01-25 at 18 07 52@2x](https://github.com/0xPolygon/cdk-validium-node/assets/5405744/dfc77caa-eb1a-4de7-bdff-7b4f77b62227)
