### PR TITLE
Fix batch request

### DIFF
--- a/test/config/test.node.config.toml
+++ b/test/config/test.node.config.toml
@@ -70,6 +70,7 @@ ReadTimeout = "60s"
 WriteTimeout = "60s"
 MaxRequestsPerIPAndSecond = 5000
 SequencerNodeURI = ""
+BatchRequestsEnabled = true
 EnableL2SuggestedGasPricePolling = true
 	[RPC.WebSockets]
 		Enabled = true


### PR DESCRIPTION
Fix batch request from explorer L2

```
zkevm-explorer-l2        | 2024-01-25T11:27:28.506 application=indexer fetcher=block_catchup first_block_number=1 last_block_number=0 [error] ** (EthereumJSONRPC.DecodeError) Failed to decode Ethereum JSONRPC response:
zkevm-explorer-l2        | 
zkevm-explorer-l2        |   request:
zkevm-explorer-l2        | 
zkevm-explorer-l2        |     url: http://zkevm-explorer-json-rpc:8124
zkevm-explorer-l2        | 
zkevm-explorer-l2        |     body: [{"id":0,"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x1",true]},{"id":1,"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x0",true]}]
zkevm-explorer-l2        | 
zkevm-explorer-l2        |   response:
zkevm-explorer-l2        | 
zkevm-explorer-l2        |     status code: 400
zkevm-explorer-l2        | 
zkevm-explorer-l2        |     body: batch requests are disabled
```