### PR TITLE
more gorelease cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ cmd/__debug_bin
 
 *metrics.txt
 coverage.out
+
+db/db-packr.go
+db/packrd/
+packrd/

--- a/.goreleaser-cdk.yaml
+++ b/.goreleaser-cdk.yaml
@@ -25,10 +25,10 @@ builds:
       - CGO_ENABLED=0
     ldflags:
       - -s -w
-      - -X github.com/0xPolygon/{{ .ProjectName }}.Version={{ replace .Version "+" "-" }}
-      - -X github.com/0xPolygon/{{ .ProjectName }}.GitRev={{ .Commit }}
-      - -X github.com/0xPolygon/{{ .ProjectName }}.BuildDate={{ .Date }}
-      - -X github.com/0xPolygon/{{ .ProjectName }}.GitBranch={{ .Branch }}
+      - -X github.com/0xPolygonHermez/zkevm-node.Version={{ .Version }}
+      - -X github.com/0xPolygonHermez/zkevm-node.GitRev={{ .Commit }}
+      - -X github.com/0xPolygonHermez/zkevm-node.BuildDate={{ .Date }}
+      - -X github.com/0xPolygonHermez/zkevm-node.GitBranch={{ .Branch }}
 
 archives:
   - files:


### PR DESCRIPTION
Fix ldflags for gorealse build to match go module, otherwise they do not get included in version. As in:

before:
```
 » dist/cdk-validium-node_darwin_arm64/zkevm-node version                                                                                                          
Version:      v0.1.0
Git revision: undefined
Git branch:   undefined
Go version:   go1.21.7
Built:        Fri, 17 Jun 1988 01:58:00 +0200
OS/Arch:      darwin/arm64
```

after:
```
» dist/cdk-validium-node_darwin_arm64/zkevm-node version                                                                                                          
Version:      0.5.13-cdk.3
Git revision: eb8be0c8c7e08629b9f90a0ca8d694d16a415d8c
Git branch:   develop
Go version:   go1.21.7
Built:        2024-02-28T18:43:24Z
OS/Arch:      darwin/arm64
```

Also, add packr2 artifacts to the .gitignore
