### PR TITLE
Handle force_batch data retrieval

### DIFF
--- a/dataavailability/dataavailability.go
+++ b/dataavailability/dataavailability.go
@@ -87,6 +87,7 @@ func (d *DataAvailability) GetBatchL2Data(batchNums []uint64, batchHashes []comm
 	return d.backend.GetSequence(d.ctx, batchHashes, dataAvailabilityMessage)
 }
 
+// GetForcedBatchL2Data retrieves, checks, and returns the raw data associated with forced batches.
 func (d *DataAvailability) GetForcedBatchL2Data(batchNumbers []uint64, expectedHashes []common.Hash) ([][]byte, error) {
 	data, err := d.state.GetForcedBatchL2DataByNumbers(d.ctx, batchNumbers, nil)
 	if err != nil {

--- a/dataavailability/interfaces.go
+++ b/dataavailability/interfaces.go
@@ -37,12 +37,14 @@ type stateInterface interface {
 	GetBatchL2DataByNumber(ctx context.Context, batchNumber uint64, dbTx pgx.Tx) ([]byte, error)
 	GetBatchL2DataByNumbers(ctx context.Context, batchNumbers []uint64, dbTx pgx.Tx) (map[uint64][]byte, error)
 	GetBatchByNumber(ctx context.Context, batchNumber uint64, dbTx pgx.Tx) (*state.Batch, error)
+	GetForcedBatchL2DataByNumbers(ctx context.Context, batchNumbers []uint64, dbTx pgx.Tx) (map[uint64][]byte, error)
 }
 
 // BatchDataProvider is used to retrieve batch data
 type BatchDataProvider interface {
 	// GetBatchL2Data retrieve the data of a batch from the DA backend. The returned data must be the pre-image of the hash
 	GetBatchL2Data(batchNum []uint64, batchHashes []common.Hash, dataAvailabilityMessage []byte) ([][]byte, error)
+	GetForcedBatchL2Data(batchNum []uint64, batchHashes []common.Hash) ([][]byte, error)
 }
 
 // DataManager is an interface for components that send and retrieve batch data

--- a/etherman/etherman_test.go
+++ b/etherman/etherman_test.go
@@ -169,6 +169,9 @@ func TestSequencedBatchesEvent(t *testing.T) {
 	batchData := [][]byte{data, data}
 	daMessage, _ := hex.DecodeString("0x123456789123456789")
 	da.Mock.On("GetBatchL2Data", batchNums, batchHashes, daMessage).Return(batchData, nil)
+	var fbn []uint64
+	var fbh []common.Hash
+	da.Mock.On("GetForcedBatchL2Data", fbn, fbh).Return([][]byte{}, nil)
 	_, err = etherman.ZkEVM.SequenceBatchesValidium(auth, sequences, uint64(time.Now().Unix()), uint64(1), auth.From, daMessage)
 	require.NoError(t, err)
 
@@ -211,6 +214,10 @@ func TestVerifyBatchEvent(t *testing.T) {
 	_, err = etherman.ZkEVM.SequenceBatchesValidium(auth, []polygonzkevm.PolygonValidiumEtrogValidiumBatchData{tx}, uint64(time.Now().Unix()), uint64(1), auth.From, daMessage)
 	require.NoError(t, err)
 	da.Mock.On("GetBatchL2Data", []uint64{2}, []common.Hash{crypto.Keccak256Hash(common.Hex2Bytes(rawTxs))}, daMessage).Return([][]byte{common.Hex2Bytes(rawTxs)}, nil)
+
+	var fbn []uint64
+	var fbh []common.Hash
+	da.Mock.On("GetForcedBatchL2Data", fbn, fbh).Return([][]byte{}, nil)
 
 	// Mine the tx in a block
 	ethBackend.Commit()
@@ -328,6 +335,10 @@ func TestSendSequences(t *testing.T) {
 	tx, err := etherman.sequenceBatches(*auth, []ethmanTypes.Sequence{sequence}, uint64(lastL2BlockTStamp), uint64(1), auth.From, daMessage)
 	require.NoError(t, err)
 	da.Mock.On("GetBatchL2Data", []uint64{2}, []common.Hash{crypto.Keccak256Hash(batchL2Data)}, daMessage).Return([][]byte{batchL2Data}, nil)
+	var fbn []uint64
+	var fbh []common.Hash
+	da.Mock.On("GetForcedBatchL2Data", fbn, fbh).Return([][]byte{}, nil)
+
 	log.Debug("TX: ", tx.Hash())
 	ethBackend.Commit()
 

--- a/etherman/interfaces.go
+++ b/etherman/interfaces.go
@@ -4,4 +4,5 @@ import "github.com/ethereum/go-ethereum/common"
 
 type dataAvailabilityProvider interface {
 	GetBatchL2Data(batchNum []uint64, hash []common.Hash, dataAvailabilityMessage []byte) ([][]byte, error)
+	GetForcedBatchL2Data(batchNumbers []uint64, expectedHashes []common.Hash) ([][]byte, error)
 }

--- a/etherman/mock_da.go
+++ b/etherman/mock_da.go
@@ -43,6 +43,36 @@ func (_m *daMock) GetBatchL2Data(batchNum []uint64, hash []common.Hash, dataAvai
 	return r0, r1
 }
 
+// GetForcedBatchL2Data provides a mock function with given fields: batchNumbers, expectedHashes
+func (_m *daMock) GetForcedBatchL2Data(batchNumbers []uint64, expectedHashes []common.Hash) ([][]byte, error) {
+	ret := _m.Called(batchNumbers, expectedHashes)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetForcedBatchL2Data")
+	}
+
+	var r0 [][]byte
+	var r1 error
+	if rf, ok := ret.Get(0).(func([]uint64, []common.Hash) ([][]byte, error)); ok {
+		return rf(batchNumbers, expectedHashes)
+	}
+	if rf, ok := ret.Get(0).(func([]uint64, []common.Hash) [][]byte); ok {
+		r0 = rf(batchNumbers, expectedHashes)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([][]byte)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func([]uint64, []common.Hash) error); ok {
+		r1 = rf(batchNumbers, expectedHashes)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // newDaMock creates a new instance of daMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func newDaMock(t interface {

--- a/state/interfaces.go
+++ b/state/interfaces.go
@@ -151,6 +151,7 @@ type storage interface {
 	GetForcedBatchParentHash(ctx context.Context, forcedBatchNumber uint64, dbTx pgx.Tx) (common.Hash, error)
 	GetBatchL2DataByNumber(ctx context.Context, batchNumber uint64, dbTx pgx.Tx) ([]byte, error)
 	GetBatchL2DataByNumbers(ctx context.Context, batchNumbers []uint64, dbTx pgx.Tx) (map[uint64][]byte, error)
+	GetForcedBatchL2DataByNumbers(ctx context.Context, batchNumbers []uint64, dbTx pgx.Tx) (map[uint64][]byte, error)
 	GetLatestBatchGlobalExitRoot(ctx context.Context, dbTx pgx.Tx) (common.Hash, error)
 	GetL2TxHashByTxHash(ctx context.Context, hash common.Hash, dbTx pgx.Tx) (*common.Hash, error)
 	GetSyncInfoData(ctx context.Context, dbTx pgx.Tx) (SyncInfoDataOnStorage, error)

--- a/state/mocks/mock_storage.go
+++ b/state/mocks/mock_storage.go
@@ -2560,6 +2560,66 @@ func (_c *StorageMock_GetForcedBatch_Call) RunAndReturn(run func(context.Context
 	return _c
 }
 
+// GetForcedBatchL2DataByNumbers provides a mock function with given fields: ctx, batchNumbers, dbTx
+func (_m *StorageMock) GetForcedBatchL2DataByNumbers(ctx context.Context, batchNumbers []uint64, dbTx pgx.Tx) (map[uint64][]byte, error) {
+	ret := _m.Called(ctx, batchNumbers, dbTx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetForcedBatchL2DataByNumbers")
+	}
+
+	var r0 map[uint64][]byte
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, []uint64, pgx.Tx) (map[uint64][]byte, error)); ok {
+		return rf(ctx, batchNumbers, dbTx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, []uint64, pgx.Tx) map[uint64][]byte); ok {
+		r0 = rf(ctx, batchNumbers, dbTx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[uint64][]byte)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, []uint64, pgx.Tx) error); ok {
+		r1 = rf(ctx, batchNumbers, dbTx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// StorageMock_GetForcedBatchL2DataByNumbers_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetForcedBatchL2DataByNumbers'
+type StorageMock_GetForcedBatchL2DataByNumbers_Call struct {
+	*mock.Call
+}
+
+// GetForcedBatchL2DataByNumbers is a helper method to define mock.On call
+//   - ctx context.Context
+//   - batchNumbers []uint64
+//   - dbTx pgx.Tx
+func (_e *StorageMock_Expecter) GetForcedBatchL2DataByNumbers(ctx interface{}, batchNumbers interface{}, dbTx interface{}) *StorageMock_GetForcedBatchL2DataByNumbers_Call {
+	return &StorageMock_GetForcedBatchL2DataByNumbers_Call{Call: _e.mock.On("GetForcedBatchL2DataByNumbers", ctx, batchNumbers, dbTx)}
+}
+
+func (_c *StorageMock_GetForcedBatchL2DataByNumbers_Call) Run(run func(ctx context.Context, batchNumbers []uint64, dbTx pgx.Tx)) *StorageMock_GetForcedBatchL2DataByNumbers_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].([]uint64), args[2].(pgx.Tx))
+	})
+	return _c
+}
+
+func (_c *StorageMock_GetForcedBatchL2DataByNumbers_Call) Return(_a0 map[uint64][]byte, _a1 error) *StorageMock_GetForcedBatchL2DataByNumbers_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *StorageMock_GetForcedBatchL2DataByNumbers_Call) RunAndReturn(run func(context.Context, []uint64, pgx.Tx) (map[uint64][]byte, error)) *StorageMock_GetForcedBatchL2DataByNumbers_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetForcedBatchParentHash provides a mock function with given fields: ctx, forcedBatchNumber, dbTx
 func (_m *StorageMock) GetForcedBatchParentHash(ctx context.Context, forcedBatchNumber uint64, dbTx pgx.Tx) (common.Hash, error) {
 	ret := _m.Called(ctx, forcedBatchNumber, dbTx)

--- a/state/pgstatestorage/pgstatestorage.go
+++ b/state/pgstatestorage/pgstatestorage.go
@@ -371,13 +371,19 @@ func (p *PostgresStorage) GetBatchL2DataByNumber(ctx context.Context, batchNumbe
 
 // GetBatchL2DataByNumbers returns the batch L2 data of the given batch numbers. The data is a union of state.batch and state.forced_batch tables.
 func (p *PostgresStorage) GetBatchL2DataByNumbers(ctx context.Context, batchNumbers []uint64, dbTx pgx.Tx) (map[uint64][]byte, error) {
-	const getBatchL2DataByBatchNumber = `
-	SELECT batch_num, raw_txs_data FROM state.batch WHERE batch_num = ANY($1)  
-	UNION
-	SELECT forced_batch_num, convert_from(decode(raw_txs_data, 'hex'), 'UTF8')::bytea FROM state.forced_batch WHERE forced_batch_num = ANY($2)
-`
+	const sql = "SELECT batch_num, raw_txs_data FROM state.batch WHERE batch_num = ANY($1)"
+	return p.getBatchData(ctx, sql, batchNumbers, dbTx)
+}
+
+// GetForcedBatchL2DataByNumbers returns the forced batch data of the given batch numbers
+func (p *PostgresStorage) GetForcedBatchL2DataByNumbers(ctx context.Context, batchNumbers []uint64, dbTx pgx.Tx) (map[uint64][]byte, error) {
+	const sql = "SELECT forced_batch_num, convert_from(decode(raw_txs_data, 'hex'), 'UTF8')::bytea FROM state.forced_batch WHERE forced_batch_num = ANY($1)"
+	return p.getBatchData(ctx, sql, batchNumbers, dbTx)
+}
+
+func (p *PostgresStorage) getBatchData(ctx context.Context, sql string, numbers []uint64, dbTx pgx.Tx) (map[uint64][]byte, error) {
 	q := p.getExecQuerier(dbTx)
-	rows, err := q.Query(ctx, getBatchL2DataByBatchNumber, batchNumbers, batchNumbers)
+	rows, err := q.Query(ctx, sql, numbers)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, state.ErrNotFound
 	} else if err != nil {
@@ -395,9 +401,6 @@ func (p *PostgresStorage) GetBatchL2DataByNumbers(ctx context.Context, batchNumb
 			return nil, err
 		}
 		batchL2DataMap[batchNum] = batchL2Data
-	}
-	if len(batchL2DataMap) == 0 {
-		return nil, state.ErrNotFound
 	}
 	return batchL2DataMap, nil
 }

--- a/state/pgstatestorage/pgstatestorage_test.go
+++ b/state/pgstatestorage/pgstatestorage_test.go
@@ -1410,7 +1410,8 @@ func TestGetForcedBatch(t *testing.T) {
 	require.Equal(t, "0x717e05de47a87a7d1679e183f1c224150675f6302b7da4eaab526b2b91ae0761", fb.GlobalExitRoot.String())
 	require.Equal(t, []byte{0xb}, fb.RawTxsData)
 
-	fbData, err := testState.GetBatchL2DataByNumber(ctx, 1, dbTx)
+	// also check data retrieval
+	fbData, err := testState.GetForcedBatchL2DataByNumbers(ctx, []uint64{1}, dbTx)
 	require.NoError(t, err)
 	require.Equal(t, []byte{0xb}, fbData)
 }


### PR DESCRIPTION
This PR implements force_batch data retrieval. It splits validium batches into normal and forced batches, retrieves the data accordingly, and recombines the results in the originally requested order.