### PR TITLE
Fix parameters provided to the `zkevm_getBatchDataByNumbers`

### DIFF
--- a/dataavailability/dataavailability.go
+++ b/dataavailability/dataavailability.go
@@ -113,7 +113,7 @@ func (d *DataAvailability) trustedSequencerData(batchNums []uint64, expectedHash
 		return nil, fmt.Errorf("invalid arguments, len of batch numbers does not equal length of expected hashes: %d != %d",
 			len(batchNums), len(expectedHashes))
 	}
-	var nums []*big.Int
+	nums := make([]*big.Int, 0, len(batchNums))
 	for _, n := range batchNums {
 		nums = append(nums, new(big.Int).SetUint64(n))
 	}
@@ -124,7 +124,7 @@ func (d *DataAvailability) trustedSequencerData(batchNums []uint64, expectedHash
 	if len(batchData) != len(batchNums) {
 		return nil, fmt.Errorf("missing batch data, expected %d, got %d", len(batchNums), len(batchData))
 	}
-	var result [][]byte
+	result := make([][]byte, 0, len(batchNums))
 	for i := 0; i < len(batchNums); i++ {
 		number := batchNums[i]
 		batch := batchData[i]

--- a/docs/json-rpc-endpoints.md
+++ b/docs/json-rpc-endpoints.md
@@ -66,6 +66,7 @@ If the endpoint is not in the list below, it means this specific endpoint is not
 - `zkevm_estimateGasPrice`
 - `zkevm_estimateCounters`
 - `zkevm_getBatchByNumber`
+- `zkevm_getBatchDataByNumbers`
 - `zkevm_getExitRootsByGER`
 - `zkevm_getFullBlockByHash`
 - `zkevm_getFullBlockByNumber`

--- a/jsonrpc/client/zkevm.go
+++ b/jsonrpc/client/zkevm.go
@@ -61,21 +61,15 @@ func (c *Client) BatchByNumber(ctx context.Context, number *big.Int) (*types.Bat
 // BatchesByNumbers returns batches from the current canonical chain by batch numbers. If the list is empty, the last
 // known batch is returned as a list.
 func (c *Client) BatchesByNumbers(_ context.Context, numbers []*big.Int) ([]*types.BatchData, error) {
-	batchNumbers := make([]string, 0, len(numbers))
+	batchNumbers := make([]types.BatchNumber, 0, len(numbers))
 	for _, n := range numbers {
-		bn := types.BatchNumber(n.Int64())
-		batchNumbers = append(batchNumbers, bn.StringOrHex())
+		batchNumbers = append(batchNumbers, types.BatchNumber(n.Int64()))
 	}
 	if len(batchNumbers) == 0 {
-		latestBatchNum := types.LatestBatchNumber
-		batchNumbers = append(batchNumbers, latestBatchNum.StringOrHex())
+		batchNumbers = append(batchNumbers, types.LatestBatchNumber)
 	}
 
-	batchNumsMap := map[string][]string{
-		"numbers": batchNumbers,
-	}
-
-	response, err := JSONRPCCall(c.url, "zkevm_getBatchDataByNumbers", batchNumsMap)
+	response, err := JSONRPCCall(c.url, "zkevm_getBatchDataByNumbers", &types.BatchFilter{Numbers: batchNumbers})
 	if err != nil {
 		return nil, err
 	}

--- a/jsonrpc/client/zkevm.go
+++ b/jsonrpc/client/zkevm.go
@@ -61,20 +61,21 @@ func (c *Client) BatchByNumber(ctx context.Context, number *big.Int) (*types.Bat
 // BatchesByNumbers returns batches from the current canonical chain by batch numbers. If the list is empty, the last
 // known batch is returned as a list.
 func (c *Client) BatchesByNumbers(_ context.Context, numbers []*big.Int) ([]*types.BatchData, error) {
-	var list []types.BatchNumber
+	batchNumbers := make([]string, 0, len(numbers))
 	for _, n := range numbers {
-		list = append(list, types.BatchNumber(n.Int64()))
+		bn := types.BatchNumber(n.Int64())
+		batchNumbers = append(batchNumbers, bn.StringOrHex())
 	}
-	if len(list) == 0 {
-		list = append(list, types.LatestBatchNumber)
-	}
-
-	var batchNumbers []string
-	for _, n := range list {
-		batchNumbers = append(batchNumbers, n.StringOrHex())
+	if len(batchNumbers) == 0 {
+		latestBatchNum := types.LatestBatchNumber
+		batchNumbers = append(batchNumbers, latestBatchNum.StringOrHex())
 	}
 
-	response, err := JSONRPCCall(c.url, "zkevm_getBatchDataByNumbers", batchNumbers, true)
+	batchNumsMap := map[string][]string{
+		"numbers": batchNumbers,
+	}
+
+	response, err := JSONRPCCall(c.url, "zkevm_getBatchDataByNumbers", batchNumsMap)
 	if err != nil {
 		return nil, err
 	}

--- a/jsonrpc/endpoints_zkevm.go
+++ b/jsonrpc/endpoints_zkevm.go
@@ -207,7 +207,7 @@ func (z *ZKEVMEndpoints) GetBatchByNumber(batchNumber types.BatchNumber, fullTx 
 // GetBatchDataByNumbers returns the batch data for batches by numbers
 func (z *ZKEVMEndpoints) GetBatchDataByNumbers(filter types.BatchFilter) (interface{}, types.Error) {
 	return z.txMan.NewDbTxScope(z.state, func(ctx context.Context, dbTx pgx.Tx) (interface{}, types.Error) {
-		var batchNumbers []uint64
+		batchNumbers := make([]uint64, 0, len(filter.Numbers))
 		for _, bn := range filter.Numbers {
 			n, rpcErr := bn.GetNumericBatchNumber(ctx, z.state, z.etherman, dbTx)
 			if rpcErr != nil {
@@ -224,7 +224,7 @@ func (z *ZKEVMEndpoints) GetBatchDataByNumbers(filter types.BatchFilter) (interf
 				fmt.Sprintf("couldn't load batch data from state by numbers %v", filter.Numbers), err, true)
 		}
 
-		var ret []*types.BatchData
+		ret := make([]*types.BatchData, 0, len(batchNumbers))
 		for _, n := range batchNumbers {
 			data := &types.BatchData{Number: types.ArgUint64(n)}
 			if b, ok := batchesData[n]; ok {

--- a/jsonrpc/endpoints_zkevm_test.go
+++ b/jsonrpc/endpoints_zkevm_test.go
@@ -2705,3 +2705,32 @@ func TestGetLatestGlobalExitRoot(t *testing.T) {
 		})
 	}
 }
+
+func TestClient_BatchesByNumbers(t *testing.T) {
+	const batchesCount = 6
+
+	s, m, _ := newSequencerMockedServer(t)
+	defer s.Stop()
+
+	batchesDataMap := make(map[uint64][]byte, batchesCount)
+	for i := 0; i < batchesCount; i++ {
+		batchesDataMap[uint64(i+1)] = []byte(fmt.Sprintf("batch %d data", i+1))
+	}
+
+	m.State.On("GetBatchL2DataByNumbers", mock.Anything, mock.Anything, mock.Anything).
+		Return(batchesDataMap, nil).Once()
+
+	m.State.On("BeginStateTransaction", context.Background()).
+		Return(m.DbTx, nil).Once()
+
+	m.DbTx.On("Commit", context.Background()).Return(nil).Once()
+
+	zkEVMClient := client.NewClient(s.ServerURL)
+	reqBatchesNum := []*big.Int{big.NewInt(1), big.NewInt(3), big.NewInt(4)}
+	result, err := zkEVMClient.BatchesByNumbers(context.Background(), reqBatchesNum)
+	require.NoError(t, err)
+	require.Len(t, result, len(reqBatchesNum))
+	for i, batchNum := range reqBatchesNum {
+		require.Equal(t, hex.EncodeToHex(batchesDataMap[batchNum.Uint64()]), result[i].BatchL2Data.Hex())
+	}
+}


### PR DESCRIPTION
The PR fixes parameters that are provided to the `zkevm_getBatchDataByNumbers`, since instead of two parameters (batch numbers and a boolean) it accepts a `BatchFilter` instance, holding batch numbers https://github.com/0xPolygon/cdk-validium-node/blob/66c329f6d1230d7bb6e9a76318b618aa93d58e1a/jsonrpc/endpoints_zkevm.go#L208