### PR TITLE
Support processing batches with forkID 9 created with previous forkID

### DIFF
--- a/synchronizer/actions/elderberry/processor_l1_sequence_batches.go
+++ b/synchronizer/actions/elderberry/processor_l1_sequence_batches.go
@@ -3,7 +3,6 @@ package elderberry
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/0xPolygonHermez/zkevm-node/etherman"
@@ -60,58 +59,12 @@ func (g *ProcessorL1SequenceBatchesElderberry) Process(ctx context.Context, orde
 
 	sbatch := l1Block.SequencedBatches[order.Pos][0]
 
+	executionTime := l1Block.ReceivedAt
 	if sbatch.SequencedBatchElderberryData == nil {
-		log.Errorf("No elderberry sequenced batch data for batch %d", sbatch.BatchNumber)
-		return fmt.Errorf("no elderberry sequenced batch data for batch %d", sbatch.BatchNumber)
+		log.Warnf("No elderberry sequenced batch data for batch %d", sbatch.BatchNumber)
+	} else {
+		executionTime = time.Unix(int64(sbatch.SequencedBatchElderberryData.MaxSequenceTimestamp), 0)
 	}
-	// We need to check that the sequence match
-	err := g.sanityCheckExpectedSequence(sbatch.SequencedBatchElderberryData.InitSequencedBatchNumber, dbTx)
-	if err != nil {
-		return err
-	}
-	// We known that the MaxSequenceTimestamp is the same for all the batches so we can use the first one
-	err = g.previousProcessor.ProcessSequenceBatches(ctx, l1Block.SequencedBatches[order.Pos], l1Block.BlockNumber, time.Unix(int64(sbatch.SequencedBatchElderberryData.MaxSequenceTimestamp), 0), dbTx)
-	// The last L2block timestamp must match MaxSequenceTimestamp
-	if err != nil {
-		return err
-	}
-	// It checks the timestamp of the last L2 block, but it's just log an error instead of refusing the event
-	_ = g.sanityCheckTstampLastL2Block(sbatch.SequencedBatchElderberryData.MaxSequenceTimestamp, dbTx)
-	return nil
-}
 
-func (g *ProcessorL1SequenceBatchesElderberry) sanityCheckExpectedSequence(initialBatchNumber uint64, dbTx pgx.Tx) error {
-	// We need to check that the sequence match
-	lastVirtualBatchNum, err := g.state.GetLastVirtualBatchNum(context.Background(), dbTx)
-	if err != nil {
-		log.Errorf("Error getting last virtual batch number: %s", err)
-		return err
-	}
-	if lastVirtualBatchNum != initialBatchNumber {
-		log.Errorf("The last virtual batch number is not the expected one. Expected: %d (last on DB), got: %d (L1 event)", lastVirtualBatchNum+1, initialBatchNumber)
-		return fmt.Errorf("the last virtual batch number is not the expected one. Expected: %d (last on DB), got: %d (L1 event) err:%w", lastVirtualBatchNum+1, initialBatchNumber, ErrInvalidInitialBatchNumber)
-	}
-	return nil
-}
-
-func (g *ProcessorL1SequenceBatchesElderberry) sanityCheckTstampLastL2Block(timeLimit uint64, dbTx pgx.Tx) error {
-	lastVirtualBatchNum, err := g.state.GetLastVirtualBatchNum(context.Background(), dbTx)
-	if err != nil {
-		log.Errorf("Error getting last virtual batch number: %s", err)
-		return err
-	}
-	lastL2Block, err := g.state.GetLastL2BlockByBatchNumber(context.Background(), lastVirtualBatchNum, dbTx)
-	if err != nil {
-		log.Errorf("Error getting last virtual batch number: %s", err)
-		return err
-	}
-	if lastL2Block == nil {
-		//TODO: find the previous batch until we find a L2 block to check the timestamp
-		return nil
-	}
-	if uint64(lastL2Block.ReceivedAt.Unix()) > timeLimit {
-		log.Errorf("The last L2 block timestamp can't be greater than timeLimit. Expected: %d (L1 event), got: %d (last L2Block)", timeLimit, lastL2Block.ReceivedAt.Unix())
-		return fmt.Errorf("wrong timestamp of  last L2 block timestamp with L1 event timestamp")
-	}
-	return nil
+	return g.previousProcessor.ProcessSequenceBatches(ctx, l1Block.SequencedBatches[order.Pos], l1Block.BlockNumber, executionTime, dbTx)
 }


### PR DESCRIPTION
This PR port fix for #123 to the `develop` branch. It enables processing batches created prior to fork id 9 on the fork id 9 codebase.