### PR TITLE
Backup batches on fork id update

### DIFF
--- a/db/migrations/state/validium-001.sql
+++ b/db/migrations/state/validium-001.sql
@@ -1,0 +1,32 @@
+-- +migrate Up
+
+CREATE TABLE IF NOT EXISTS state.batch_data_backup
+(
+    batch_num  BIGINT,
+    data       BYTEA,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (batch_num, created_at)
+);
+
+-- +migrate StatementBegin
+CREATE OR REPLACE FUNCTION backup_batch() RETURNS trigger AS $$
+    BEGIN
+        INSERT  INTO state.batch_data_backup (batch_num,     data) 
+                VALUES                       (OLD.batch_num, OLD.raw_txs_data)
+                ON CONFLICT (batch_num, created_at) DO UPDATE SET
+                    data = EXCLUDED.data;
+        RETURN OLD;
+    END;
+$$
+LANGUAGE plpgsql;
+-- +migrate StatementEnd
+
+CREATE TRIGGER backup_batch
+   BEFORE DELETE ON state.batch FOR EACH ROW
+   EXECUTE PROCEDURE backup_batch();
+
+-- +migrate Down
+
+DROP TRIGGER IF EXISTS backup_batch ON state.batch;
+DROP FUNCTION IF EXISTS backup_batch();
+DROP TABLE IF EXISTS state.batch_data_backup;

--- a/state/pgstatestorage/pgstatestorage.go
+++ b/state/pgstatestorage/pgstatestorage.go
@@ -364,6 +364,25 @@ func (p *PostgresStorage) GetBatchL2DataByNumber(ctx context.Context, batchNumbe
 	err := q.QueryRow(ctx, getBatchL2DataByBatchNumber, batchNumber).Scan(&batchL2Data)
 
 	if errors.Is(err, pgx.ErrNoRows) {
+		return p.GetBatchL2DataByNumberFromBackup(ctx, batchNumber, dbTx)
+	} else if err != nil {
+		return nil, err
+	}
+	return batchL2Data, nil
+}
+
+// GetBatchL2DataByNumberFromBackup returns the batch L2 data of the given batch number from the backup table
+func (p *PostgresStorage) GetBatchL2DataByNumberFromBackup(ctx context.Context, batchNumber uint64, dbTx pgx.Tx) ([]byte, error) {
+	getBatchL2DataByBatchNumber := `
+		SELECT data FROM state.batch_data_backup
+		WHERE batch_num = $1
+		ORDER BY created_at DESC
+		LIMIT 1
+	`
+	q := p.getExecQuerier(dbTx)
+	var batchL2Data []byte
+	err := q.QueryRow(ctx, getBatchL2DataByBatchNumber, batchNumber).Scan(&batchL2Data)
+	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, state.ErrNotFound
 	} else if err != nil {
 		return nil, err

--- a/state/pgstatestorage/pgstatestorage.go
+++ b/state/pgstatestorage/pgstatestorage.go
@@ -363,9 +363,11 @@ func (p *PostgresStorage) GetBatchL2DataByNumber(ctx context.Context, batchNumbe
 	var batchL2Data []byte
 	err := q.QueryRow(ctx, getBatchL2DataByBatchNumber, batchNumber).Scan(&batchL2Data)
 
-	if errors.Is(err, pgx.ErrNoRows) {
-		return p.GetBatchL2DataByNumberFromBackup(ctx, batchNumber, dbTx)
-	} else if err != nil {
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return p.GetBatchL2DataByNumberFromBackup(ctx, batchNumber, dbTx)
+		}
+
 		return nil, err
 	}
 	return batchL2Data, nil

--- a/state/pgstatestorage/pgstatestorage_test.go
+++ b/state/pgstatestorage/pgstatestorage_test.go
@@ -1142,7 +1142,10 @@ func TestGetBatchL2DataByNumber(t *testing.T) {
 
 	// empty case
 	var batchNum uint64 = 4
-	const openBatchSQL = "INSERT INTO state.batch (batch_num, raw_txs_data, wip) VALUES ($1, $2, false)"
+	const (
+		openBatchSQL    = "INSERT INTO state.batch (batch_num, raw_txs_data, wip) VALUES ($1, $2, false)"
+		resetBatchesSQL = "DELETE FROM state.batch"
+	)
 	_, err = tx.Exec(ctx, openBatchSQL, batchNum, nil)
 	require.NoError(t, err)
 	data, err := testState.GetBatchL2DataByNumber(ctx, batchNum, tx)
@@ -1155,6 +1158,32 @@ func TestGetBatchL2DataByNumber(t *testing.T) {
 	_, err = tx.Exec(ctx, openBatchSQL, batchNum, expectedData)
 	require.NoError(t, err)
 	actualData, err := testState.GetBatchL2DataByNumber(ctx, batchNum, tx)
+	require.NoError(t, err)
+	assert.Equal(t, expectedData, actualData)
+
+	// Force backup
+	_, err = tx.Exec(ctx, resetBatchesSQL)
+	require.NoError(t, err)
+
+	// Get batch 4 from backup
+	batchNum = 4
+	data, err = testState.GetBatchL2DataByNumber(ctx, batchNum, tx)
+	require.NoError(t, err)
+	assert.Nil(t, data)
+
+	// Get batch 5 from backup
+	batchNum = 5
+	actualData, err = testState.GetBatchL2DataByNumber(ctx, batchNum, tx)
+	require.NoError(t, err)
+	assert.Equal(t, expectedData, actualData)
+
+	// Update batch 5 and get it from backup
+	expectedData = []byte("new foo bar")
+	_, err = tx.Exec(ctx, openBatchSQL, batchNum, expectedData)
+	require.NoError(t, err)
+	_, err = tx.Exec(ctx, resetBatchesSQL)
+	require.NoError(t, err)
+	actualData, err = testState.GetBatchL2DataByNumber(ctx, batchNum, tx)
 	require.NoError(t, err)
 	assert.Equal(t, expectedData, actualData)
 }


### PR DESCRIPTION
This PR (back)ports bug fix, prevents batches data lost when the fork id gets updated (and when the trusted state gets reseted, namely the `state.batch` gets cleared).