### PR TITLE
perf: use errors.New to replace fmt.Errorf with no parameters

### DIFF
--- a/state/converters.go
+++ b/state/converters.go
@@ -2,7 +2,7 @@ package state
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"math/big"
 	"time"
 
@@ -95,7 +95,7 @@ func convertToReadWriteAddresses(addresses map[string]*executor.InfoReadWrite) (
 			bigNonce, ok := new(big.Int).SetString(addrInfo.Nonce, encoding.Base10)
 			if !ok {
 				log.Debugf("received nonce as string: %v", addrInfo.Nonce)
-				return nil, fmt.Errorf("error while parsing address nonce")
+				return nil, errors.New("error while parsing address nonce")
 			}
 			nonceNp := bigNonce.Uint64()
 			nonce = &nonceNp
@@ -105,7 +105,7 @@ func convertToReadWriteAddresses(addresses map[string]*executor.InfoReadWrite) (
 			balance, ok = new(big.Int).SetString(addrInfo.Balance, encoding.Base10)
 			if !ok {
 				log.Debugf("received balance as string: %v", addrInfo.Balance)
-				return nil, fmt.Errorf("error while parsing address balance")
+				return nil, errors.New("error while parsing address balance")
 			}
 		}
 

--- a/state/convertersV2.go
+++ b/state/convertersV2.go
@@ -331,7 +331,7 @@ func convertToReadWriteAddressesV2(addresses map[string]*executor.InfoReadWriteV
 			bigNonce, ok := new(big.Int).SetString(addrInfo.Nonce, encoding.Base10)
 			if !ok {
 				log.Debugf("received nonce as string: %v", addrInfo.Nonce)
-				return nil, fmt.Errorf("error while parsing address nonce")
+				return nil, errors.New("error while parsing address nonce")
 			}
 			nonceNp := bigNonce.Uint64()
 			nonce = &nonceNp
@@ -341,7 +341,7 @@ func convertToReadWriteAddressesV2(addresses map[string]*executor.InfoReadWriteV
 			balance, ok = new(big.Int).SetString(addrInfo.Balance, encoding.Base10)
 			if !ok {
 				log.Debugf("received balance as string: %v", addrInfo.Balance)
-				return nil, fmt.Errorf("error while parsing address balance")
+				return nil, errors.New("error while parsing address balance")
 			}
 		}
 

--- a/state/errors.go
+++ b/state/errors.go
@@ -21,9 +21,9 @@ var (
 	// ErrAlreadyInitializedDBTransaction indicates the db transaction was already initialized
 	ErrAlreadyInitializedDBTransaction = errors.New("database transaction already initialized")
 	// ErrNotEnoughIntrinsicGas indicates the gas is not enough to cover the intrinsic gas cost
-	ErrNotEnoughIntrinsicGas = fmt.Errorf("not enough gas supplied for intrinsic gas costs")
+	ErrNotEnoughIntrinsicGas = errors.New("not enough gas supplied for intrinsic gas costs")
 	// ErrParsingExecutorTrace indicates an error occurred while parsing the executor trace
-	ErrParsingExecutorTrace = fmt.Errorf("error while parsing executor trace")
+	ErrParsingExecutorTrace = errors.New("error while parsing executor trace")
 	// ErrInvalidBatchNumber indicates the provided batch number is not the latest in db
 	ErrInvalidBatchNumber = errors.New("provided batch number is not latest")
 	// ErrLastBatchShouldBeClosed indicates that last batch needs to be closed before adding a new one

--- a/state/runtime/executor/errors.go
+++ b/state/runtime/executor/errors.go
@@ -1,7 +1,7 @@
 package executor
 
 import (
-	"fmt"
+	"errors"
 	"math"
 
 	"github.com/0xPolygonHermez/zkevm-node/state/runtime"
@@ -9,15 +9,15 @@ import (
 
 var (
 	// ErrExecutorUnspecified indicates an unspecified executor error
-	ErrExecutorUnspecified = fmt.Errorf("unspecified executor error")
+	ErrExecutorUnspecified = errors.New("unspecified executor error")
 	// ErrROMUnspecified indicates an unspecified ROM error
-	ErrROMUnspecified = fmt.Errorf("unspecified ROM error")
+	ErrROMUnspecified = errors.New("unspecified ROM error")
 	// ErrExecutorUnknown indicates an unknown executor error
-	ErrExecutorUnknown = fmt.Errorf("unknown executor error")
+	ErrExecutorUnknown = errors.New("unknown executor error")
 	// ErrCodeExecutorUnknown indicates an unknown executor error
 	ErrCodeExecutorUnknown = ExecutorError(math.MaxInt32)
 	// ErrROMUnknown indicates an unknown ROM error
-	ErrROMUnknown = fmt.Errorf("unknown ROM error")
+	ErrROMUnknown = errors.New("unknown ROM error")
 	// ErrCodeROMUnknown indicates an unknown ROM error
 	ErrCodeROMUnknown = RomError(math.MaxInt32)
 )

--- a/state/runtime/instrumentation/js/goja.go
+++ b/state/runtime/instrumentation/js/goja.go
@@ -88,7 +88,7 @@ func fromBuf(vm *goja.Runtime, bufType goja.Value, buf goja.Value, allowString b
 		b := obj.Get("buffer").Export().(goja.ArrayBuffer).Bytes()
 		return b, nil
 	}
-	return nil, fmt.Errorf("invalid buffer type")
+	return nil, errors.New("invalid buffer type")
 }
 
 // jsTracer is an implementation of the Tracer interface which evaluates

--- a/state/runtime/instrumentation/tracers/tracers.go
+++ b/state/runtime/instrumentation/tracers/tracers.go
@@ -19,6 +19,7 @@ package tracers
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/big"
 
@@ -105,7 +106,7 @@ const (
 // It zero-pads the slice if it extends beyond memory bounds.
 func GetMemoryCopyPadded(m *fakevm.Memory, offset, size int64) ([]byte, error) {
 	if offset < 0 || size < 0 {
-		return nil, fmt.Errorf("offset or size must not be negative")
+		return nil, errors.New("offset or size must not be negative")
 	}
 	if int(offset+size) < m.Len() { // slice fully inside memory
 		return m.GetCopy(offset, size), nil

--- a/state/trace.go
+++ b/state/trace.go
@@ -341,7 +341,7 @@ func (s *State) DebugTransaction(ctx context.Context, transactionHash common.Has
 	// Sanity check
 	log.Debugf(response.TxHash.String())
 	if response.TxHash != transactionHash {
-		return nil, fmt.Errorf("tx hash not found in executor response")
+		return nil, errors.New("tx hash not found in executor response")
 	}
 
 	result := &runtime.ExecutionResult{
@@ -385,7 +385,7 @@ func (s *State) DebugTransaction(ctx context.Context, transactionHash common.Has
 	gasPrice, ok := new(big.Int).SetString(context.GasPrice, encoding.Base10)
 	if !ok {
 		log.Errorf("debug transaction: failed to parse gasPrice")
-		return nil, fmt.Errorf("failed to parse gasPrice")
+		return nil, errors.New("failed to parse gasPrice")
 	}
 
 	// select and prepare tracer

--- a/state/transaction.go
+++ b/state/transaction.go
@@ -171,7 +171,7 @@ func (s *State) StoreTransactions(ctx context.Context, batchNumber uint64, proce
 
 			receipt := GenerateReceipt(header.Number, processedTx, uint(i), forkID)
 			if !CheckLogOrder(receipt.Logs) {
-				return fmt.Errorf("error: logs received from executor are not in order")
+				return errors.New("error: logs received from executor are not in order")
 			}
 			receipts := []*types.Receipt{receipt}
 			imStateRoots := []common.Hash{processedTx.StateRoot}

--- a/test/operations/wait.go
+++ b/test/operations/wait.go
@@ -40,7 +40,7 @@ const (
 var (
 	// ErrTimeoutReached is thrown when the timeout is reached and
 	// because the condition is not matched
-	ErrTimeoutReached = fmt.Errorf("timeout has been reached")
+	ErrTimeoutReached = errors.New("timeout has been reached")
 )
 
 // Wait handles polliing until conditions are met.
@@ -186,7 +186,7 @@ func WaitBatchToBeConsolidated(batchNum uint64, timeout time.Duration, state *st
 
 func WaitTxReceipt(ctx context.Context, txHash common.Hash, timeout time.Duration, client *ethclient.Client) (*types.Receipt, error) {
 	if client == nil {
-		return nil, fmt.Errorf("client is nil")
+		return nil, errors.New("client is nil")
 	}
 	var receipt *types.Receipt
 	pollErr := Poll(DefaultInterval, timeout, func() (bool, error) {

--- a/test/testutils/utils.go
+++ b/test/testutils/utils.go
@@ -1,6 +1,7 @@
 package testutils
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -57,10 +58,10 @@ func CheckError(err error, expected bool, msg string) error {
 	}
 	if expected {
 		if err == nil {
-			return fmt.Errorf("Expected error didn't happen")
+			return errors.New("Expected error didn't happen")
 		}
 		if msg == "" {
-			return fmt.Errorf("Expected error message not defined")
+			return errors.New("Expected error message not defined")
 		}
 		if !strings.HasPrefix(err.Error(), msg) {
 			return fmt.Errorf("Wrong error, expected %q, got %q", msg, err.Error())
@@ -75,7 +76,7 @@ func ReadBytecode(contractPath string) (string, error) {
 
 	_, currentFilename, _, ok := runtime.Caller(0)
 	if !ok {
-		return "", fmt.Errorf("Could not get name of current file")
+		return "", errors.New("Could not get name of current file")
 	}
 	fullBasePath := path.Join(path.Dir(currentFilename), basePath)
 


### PR DESCRIPTION
If you don't need to format the string, recommended to use error.New().