### PR TITLE
[CDK-187]: Aggregator timeout issue

### DIFF
--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -1317,7 +1317,7 @@ func (a *Aggregator) handleMonitoredTxResult(result ethtxmanager.MonitoredTxResu
 func (a *Aggregator) waitForSyncronizerToSyncUp(ctx context.Context, batchNum *uint64) error {
 	for {
 		log.Info("Waiting for the synchronizer to sync...")
-		synced, err := a.isSynced(a.ctx, batchNum)
+		synced, err := a.isSynced(ctx, batchNum)
 		if err != nil && errors.Is(err, context.Canceled) {
 			// if context is canceled, stop the loop, since it will never
 			// be able to execute properly and break in this case, and we will be stuck in it forever

--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -495,8 +495,8 @@ func (a *Aggregator) tryBuildFinalProof(ctx context.Context, prover proverInterf
 	}
 	log.Debug("Send final proof time reached")
 
-	if err = a.waitForSyncronizerToSyncUp(ctx, nil); err != nil {
-		log.Warn("waiting for the syncronizer to sync up was canceled", err)
+	if err = a.waitForSynchronizerToSyncUp(ctx, nil); err != nil {
+		log.Warn("waiting for the synchronizer to sync up was canceled", err)
 		return false, err
 	}
 
@@ -1301,8 +1301,8 @@ func (a *Aggregator) handleMonitoredTxResult(result ethtxmanager.MonitoredTxResu
 
 	// wait for the synchronizer to catch up the verified batches
 	log.Debug("A final proof has been sent, waiting for the network to be synced")
-	if err := a.waitForSyncronizerToSyncUp(a.ctx, &proofBatchNumberFinal); err != nil {
-		log.Warn("waiting for the syncronizer to sync up was canceled", err)
+	if err := a.waitForSynchronizerToSyncUp(a.ctx, &proofBatchNumberFinal); err != nil {
+		log.Warn("waiting for the synchronizer to sync up was canceled", err)
 		return
 	}
 
@@ -1314,9 +1314,9 @@ func (a *Aggregator) handleMonitoredTxResult(result ethtxmanager.MonitoredTxResu
 	}
 }
 
-func (a *Aggregator) waitForSyncronizerToSyncUp(ctx context.Context, batchNum *uint64) error {
+func (a *Aggregator) waitForSynchronizerToSyncUp(ctx context.Context, batchNum *uint64) error {
 	for {
-		log.Info("Waiting for the synchronizer to sync...")
+		log.Info("waiting for the synchronizer to sync...")
 		synced, err := a.isSynced(ctx, batchNum)
 		if err != nil && errors.Is(err, context.Canceled) {
 			// if context is canceled, stop the loop, since it will never

--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -490,10 +490,9 @@ func (a *Aggregator) tryBuildFinalProof(ctx context.Context, prover proverInterf
 	}
 	log.Debug("Send final proof time reached")
 
-	for !a.isSynced(ctx, nil) {
-		log.Info("Waiting for synchronizer to sync...")
-		time.Sleep(a.cfg.RetryTime.Duration)
-		continue
+	if err = a.waitForSyncronizerToSyncUp(ctx, nil); err != nil {
+		log.Warn("waiting for the syncronizer to sync up was canceled", err)
+		return false, err
 	}
 
 	var lastVerifiedBatchNum uint64
@@ -1069,41 +1068,41 @@ func (a *Aggregator) resetVerifyProofTime() {
 
 // isSynced checks if the state is synchronized with L1. If a batch number is
 // provided, it makes sure that the state is synced with that batch.
-func (a *Aggregator) isSynced(ctx context.Context, batchNum *uint64) bool {
+func (a *Aggregator) isSynced(ctx context.Context, batchNum *uint64) (bool, error) {
 	// get latest verified batch as seen by the synchronizer
 	lastVerifiedBatch, err := a.State.GetLastVerifiedBatch(ctx, nil)
 	if err == state.ErrNotFound {
-		return false
+		return false, nil
 	}
 	if err != nil {
 		log.Warnf("Failed to get last consolidated batch: %v", err)
-		return false
+		return false, err
 	}
 
 	if lastVerifiedBatch == nil {
-		return false
+		return false, nil
 	}
 
 	if batchNum != nil && lastVerifiedBatch.BatchNumber < *batchNum {
 		log.Infof("Waiting for the state to be synced, lastVerifiedBatchNum: %d, waiting for batch: %d", lastVerifiedBatch.BatchNumber, batchNum)
-		return false
+		return false, nil
 	}
 
 	// latest verified batch in L1
 	lastVerifiedEthBatchNum, err := a.Ethman.GetLatestVerifiedBatchNum()
 	if err != nil {
 		log.Warnf("Failed to get last eth batch, err: %v", err)
-		return false
+		return false, err
 	}
 
 	// check if L2 is synced with L1
 	if lastVerifiedBatch.BatchNumber < lastVerifiedEthBatchNum {
 		log.Infof("Waiting for the state to be synced, lastVerifiedBatchNum: %d, lastVerifiedEthBatchNum: %d, waiting for batch",
 			lastVerifiedBatch.BatchNumber, lastVerifiedEthBatchNum)
-		return false
+		return false, nil
 	}
 
-	return true
+	return true, nil
 }
 
 func (a *Aggregator) buildInputProver(ctx context.Context, batchToVerify *state.Batch) (*prover.InputProver, error) {
@@ -1297,9 +1296,9 @@ func (a *Aggregator) handleMonitoredTxResult(result ethtxmanager.MonitoredTxResu
 
 	// wait for the synchronizer to catch up the verified batches
 	log.Debug("A final proof has been sent, waiting for the network to be synced")
-	for !a.isSynced(a.ctx, &proofBatchNumberFinal) {
-		log.Info("Waiting for synchronizer to sync...")
-		time.Sleep(a.cfg.RetryTime.Duration)
+	if err := a.waitForSyncronizerToSyncUp(a.ctx, &proofBatchNumberFinal); err != nil {
+		log.Warn("waiting for the syncronizer to sync up was canceled", err)
+		return
 	}
 
 	// network is synced with the final proof, we can safely delete all recursive
@@ -1307,6 +1306,24 @@ func (a *Aggregator) handleMonitoredTxResult(result ethtxmanager.MonitoredTxResu
 	err = a.State.CleanupGeneratedProofs(a.ctx, proofBatchNumberFinal, nil)
 	if err != nil {
 		log.Errorf("Failed to store proof aggregation result: %v", err)
+	}
+}
+
+func (a *Aggregator) waitForSyncronizerToSyncUp(ctx context.Context, batchNum *uint64) error {
+	for {
+		log.Info("Waiting for the synchronizer to sync...")
+		synced, err := a.isSynced(a.ctx, batchNum)
+		if err != nil && errors.Is(err, context.Canceled) {
+			// if context is canceled, stop the loop, since it will never
+			// be able to execute properly and break in this case, and we will be stuck in it forever
+			return err
+		}
+
+		if synced {
+			return nil
+		}
+
+		time.Sleep(a.cfg.RetryTime.Duration)
 	}
 }
 

--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -227,6 +227,11 @@ func (a *Aggregator) Channel(stream prover.AggregatorService_ChannelServer) erro
 			_, err = a.tryBuildFinalProof(ctx, prover, nil)
 			if err != nil {
 				log.Errorf("Error checking proofs to verify: %v", err)
+
+				if errors.Is(err, context.Canceled) {
+					// the context was canceled, just continue, the loop will stop in the <-ctx.Done() case
+					continue
+				}
 			}
 
 			proofGenerated, err := a.tryAggregateProofs(ctx, prover)

--- a/aggregator/aggregator_test.go
+++ b/aggregator/aggregator_test.go
@@ -1456,7 +1456,7 @@ func TestIsSynced(t *testing.T) {
 	}
 }
 
-func TestWaitForSyncronizerToSyncUp(t *testing.T) {
+func TestWaitForSynchronizerToSyncUp(t *testing.T) {
 	t.Parallel()
 
 	cfg := Config{}
@@ -1517,7 +1517,7 @@ func TestWaitForSyncronizerToSyncUp(t *testing.T) {
 				tc.setup(m, &a)
 			}
 
-			err = a.waitForSyncronizerToSyncUp(a.ctx, tc.batchNum)
+			err = a.waitForSynchronizerToSyncUp(a.ctx, tc.batchNum)
 			if tc.synced {
 				assert.NoError(t, err)
 			} else {

--- a/aggregator/aggregator_test.go
+++ b/aggregator/aggregator_test.go
@@ -1450,9 +1450,79 @@ func TestIsSynced(t *testing.T) {
 				tc.setup(m, &a)
 			}
 
-			synced := a.isSynced(a.ctx, tc.batchNum)
-
+			synced, _ := a.isSynced(a.ctx, tc.batchNum)
 			assert.Equal(tc.synced, synced)
+		})
+	}
+}
+
+func TestWaitForSyncronizerToSyncUp(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{}
+	batchNum := uint64(42)
+	testCases := []struct {
+		name     string
+		setup    func(mox, *Aggregator)
+		batchNum *uint64
+		synced   bool
+	}{
+		{
+			name:     "state context canceled",
+			synced:   false,
+			batchNum: &batchNum,
+			setup: func(m mox, a *Aggregator) {
+				m.stateMock.On("GetLastVerifiedBatch", mock.Anything, nil).Return(nil, context.Canceled).Once()
+			},
+		},
+		{
+			name:     "ok after multiple iterations",
+			synced:   true,
+			batchNum: &batchNum,
+			setup: func(m mox, a *Aggregator) {
+				latestVerifiedBatch := state.VerifiedBatch{BatchNumber: batchNum}
+				m.stateMock.On("GetLastVerifiedBatch", mock.Anything, nil).Return(nil, nil).Once()
+				m.stateMock.On("GetLastVerifiedBatch", mock.Anything, nil).Return(&latestVerifiedBatch, nil).Once()
+				m.etherman.On("GetLatestVerifiedBatchNum").Return(batchNum, nil).Once()
+			},
+		},
+		{
+			name:     "ok with batch number",
+			synced:   true,
+			batchNum: &batchNum,
+			setup: func(m mox, a *Aggregator) {
+				latestVerifiedBatch := state.VerifiedBatch{BatchNumber: batchNum}
+				m.stateMock.On("GetLastVerifiedBatch", mock.Anything, nil).Return(&latestVerifiedBatch, nil).Once()
+				m.etherman.On("GetLatestVerifiedBatchNum").Return(batchNum, nil).Once()
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			stateMock := mocks.NewStateMock(t)
+			ethTxManager := mocks.NewEthTxManager(t)
+			etherman := mocks.NewEtherman(t)
+			proverMock := mocks.NewProverMock(t)
+			a, err := New(cfg, stateMock, ethTxManager, etherman, nil, nil)
+			require.NoError(t, err)
+			aggregatorCtx := context.WithValue(context.Background(), "owner", "aggregator") //nolint:staticcheck
+			a.ctx, a.exit = context.WithCancel(aggregatorCtx)
+			m := mox{
+				stateMock:    stateMock,
+				ethTxManager: ethTxManager,
+				etherman:     etherman,
+				proverMock:   proverMock,
+			}
+			if tc.setup != nil {
+				tc.setup(m, &a)
+			}
+
+			err = a.waitForSyncronizerToSyncUp(a.ctx, tc.batchNum)
+			if tc.synced {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
While trying to build and aggregate proofs, the aggregator has a for loop, where it waits for the syncronizer to sync up. That loop doesn't have a break point if the context provided by the prover communication channel is canceled, leaving it in the infinite loop state, since it constantly returns the `context canceled` error, and just tries to wait again and again.

This PR provides a fix which breakes the infinite loop if the context was canceled.

The main cause of this issue is the context which aggregator uses, which is the one provided by the prover communication channel. If the connection to the prover is lost (the context is canceled), we can end up in the situation where the old channel is still alive and in infinite loop trying to wait for the syncronizer by using the same context.

The fix breaks the loop, returns an error, which will eventually stop the old (closed channel), and the connection can be re-established again. 